### PR TITLE
Skip includes which contain variables in path

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -62,6 +62,8 @@ def find_children(playbook):
     items = _playbook_items(pb_data)
     for item in items:
         for child in play_children(basedir, item, playbook[1]):
+            if ansible.utils.contains_vars(child['path']):
+                continue
             path = shlex.split(child['path'])[0]  # strip tags=smsng
             results.append({
                 'path': ansible.utils.path_dwim(basedir, path),

--- a/test/taskincludes.txt
+++ b/test/taskincludes.txt
@@ -2,3 +2,4 @@
 - hosts: webservers
   tasks:
     - include: nestedincludes.txt tags=nested
+    - include: "{{ name }}.txt"


### PR DESCRIPTION
Unfortunately I have to use variables inside `include` path and ansible-lint cannot lint following `test.yml` playbook:

```
# test.yml
- name: test
  connection: local
  hosts: localhost
  tasks:
    - debug: msg="Hello world from test.yml!"
- include: "test-{{ name }}.yml"
```

```
# test-x.yml
- name: test
  connection: local
  hosts: localhost
  tasks:
    - debug: msg="Hello world from test-{{ name }}.yml!"
```

Ansible output:

```
$ ansible-playbook -i localhost, test.yml -e 'name=x'

PLAY [test] ******************************************************************* 

GATHERING FACTS *************************************************************** 
ok: [localhost]

TASK: [debug msg="Hello world test.yml!"] ************************************* 
ok: [localhost] => {
    "msg": "Hello world test.yml!"
}

PLAY [test] ******************************************************************* 

GATHERING FACTS *************************************************************** 
ok: [localhost]

TASK: [debug msg="Hello world from test-{{ name }}.yml!"] ********************* 
ok: [localhost] => {
    "msg": "Hello world from test-x.yml!"
}

PLAY RECAP ******************************************************************** 
localhost                  : ok=4    changed=0    unreachable=0    failed=0   
```

It is possible to evaluate path before `shlex.split()` but we can't be sure, that required var will be set.
