### PR TITLE
Add Parseable output format

### DIFF
--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -44,6 +44,9 @@ def main(args):
                       action='store_true', help="list all the rules")
     parser.add_option('-q', dest='quiet', default=False, action='store_true',
                       help="quieter, although not silent output")
+    parser.add_option('-p', dest='parseable',
+                      default=False, action='store_true',
+                      help="parseable output in the format of pep8")
     parser.add_option('-r', action='append', dest='rulesdir',
                       default=[], type='str',
                       help="add one or more rules directories using "
@@ -61,6 +64,9 @@ def main(args):
 
     if options.quiet:
         formatter = formatters.QuietFormatter()
+
+    if options.parseable:
+        formatter = formatters.ParseableFormatter()
 
     if len(args) == 0 and not (options.listrules or options.listtags):
         parser.print_help(file=sys.stderr)

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -15,3 +15,14 @@ class QuietFormatter:
         formatstr = "[{0}] {1}:{2}"
         return formatstr.format(match.rule.id, match.filename,
                                 match.linenumber)
+
+
+class ParseableFormatter:
+
+    def format(self, match):
+        formatstr = "{0}:{1}: {2} {3}"
+        return formatstr.format(match.filename,
+                                match.linenumber,
+                                match.rule.id,
+                                match.message,
+                                )


### PR DESCRIPTION
Add a 'parseable' output which outputs lines as
"<filename>:<linenumber>: <rule.id> <message>"

- Add class ParseableFormatter
- Add commandline option -p --parseable

Resolves #41