### PR TITLE
Exclude apt-get build-dep from commands instead of modules test

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -39,6 +39,11 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     def matchtask(self, file, task):
         if task["action"]["module"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
+
+            # At this point, there is no equivalent of apt-get build-dep
+            if executable == 'apt-get' and task["action"]["module_arguments"][1] == 'build-dep':
+                return False
+
             if executable in self._modules:
                 message = "{0} used in place of {1} module"
                 return message.format(executable, self._modules[executable])


### PR DESCRIPTION
There is currently no ansible equivalent of apt-get build-dep, so this PR excludes it from the test until this feature appears.