### PR TITLE
Make backward compatible with ansible 1.7.x

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -86,7 +86,7 @@ def find_children(playbook):
     items = _playbook_items(pb_data)
     for item in items:
         for child in play_children(basedir, item, playbook[1]):
-            if ansible.utils.contains_vars(child['path']):
+            if "$" in child['path'] or "{{" in child['path']:
                 continue
             path = shlex.split(child['path'])[0]  # strip tags=smsng
             results.append({


### PR DESCRIPTION
See issue #47. To test, use ansible 1.7.x and try to run ansible-lint on examples/include.yml. It will fail due to lack of contains_vars() function definition. This commit simply inlines the singular usage of this function such that one can use ansible-lint with ansible 1.7.x.