### PR TITLE
Add brackets around rule ID in parseable format.

### DIFF
--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -20,7 +20,7 @@ class QuietFormatter:
 class ParseableFormatter:
 
     def format(self, match):
-        formatstr = "{0}:{1}: {2} {3}"
+        formatstr = "{0}:{1}: [{2}] {3}"
         return formatstr.format(match.filename,
                                 match.linenumber,
                                 match.rule.id,


### PR DESCRIPTION
This formatter was supposed to model after the PEP8 output format,
but was incorrect. The actualy format is:
`"<filename>:<linenumber>: [<rule.id>] <message>"`

Follow-up to #41 and #43.