### PR TITLE
Use the DEFAULT_ROLES_PATH constant from ansible to find the role paths

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -22,7 +22,6 @@ from collections import defaultdict
 import os
 
 import ansiblelint.utils
-import ansible.utils
 
 
 class AnsibleLintRule(object):
@@ -57,7 +56,7 @@ class AnsibleLintRule(object):
         matches = []
         yaml = ansiblelint.utils.parse_yaml_linenumbers(text)
         if yaml:
-            for task in utils.get_action_tasks(yaml, file):
+            for task in ansiblelint.utils.get_action_tasks(yaml, file):
                 if 'skip_ansible_lint' in task.get('tags', []):
                     continue
                 if 'action' in task:
@@ -132,7 +131,7 @@ class RulesCollection(object):
     @classmethod
     def create_from_directory(cls, rulesdir):
         result = cls()
-        result.rules = utils.load_plugins(os.path.expanduser(rulesdir))
+        result.rules = ansiblelint.utils.load_plugins(os.path.expanduser(rulesdir))
         return result
 
 
@@ -168,7 +167,7 @@ class Runner:
         visited = set()
         while (visited != self.playbooks):
             for arg in self.playbooks - visited:
-                for file in utils.find_children(arg):
+                for file in ansiblelint.utils.find_children(arg):
                     self.playbooks.add((file['path'], file['type']))
                     files.append(file)
                 visited.add(arg)

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -142,7 +142,8 @@ def _rolepath(basedir, role):
         ansible.utils.path_dwim(basedir, os.path.join('roles', role)),
         ansible.utils.path_dwim(basedir, role),
         # if included from roles/meta/main.yml
-        ansible.utils.path_dwim(basedir, os.path.join('..', '..', 'roles', role))
+        ansible.utils.path_dwim(basedir,
+                                os.path.join('..', '..', 'roles', role))
     ]
 
     if C.DEFAULT_ROLES_PATH:

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -24,6 +24,7 @@ import imp
 import ansible.utils
 import shlex
 from ansible.playbook.task import Task
+import ansible.constants as C
 import yaml
 from yaml.composer import Composer
 from yaml.constructor import Constructor
@@ -134,18 +135,28 @@ def _roles_children(basedir, k, v, parent_type):
 
 
 def _rolepath(basedir, role):
-    if os.path.isabs(role):
-        return role
-    # if included from a playbook
-    pbrolepath = ansible.utils.path_dwim(basedir, os.path.join('roles', role))
-    if os.path.exists(pbrolepath):
-        return pbrolepath
-    # if included from roles/meta/main.yml
-    gpdir = os.path.normpath(os.path.join(basedir, '..', '..'))
-    if os.path.basename(gpdir) == 'roles':
-        rolepath = os.path.join(gpdir, role)
-        return rolepath
-    return basedir
+    role_path = None
+
+    possible_paths = [
+        # if included from a playbook
+        ansible.utils.path_dwim(basedir, os.path.join('roles', role)),
+        ansible.utils.path_dwim(basedir, role),
+        # if included from roles/meta/main.yml
+        ansible.utils.path_dwim(basedir, os.path.join('..', '..', 'roles', role))
+    ]
+
+    if C.DEFAULT_ROLES_PATH:
+        search_locations = C.DEFAULT_ROLES_PATH.split(os.pathsep)
+        for loc in search_locations:
+            loc = os.path.expanduser(loc)
+            possible_paths.append(ansible.utils.path_dwim(loc, role))
+
+    for path_option in possible_paths:
+        if os.path.isdir(path_option):
+            role_path = path_option
+            break
+
+    return role_path
 
 
 def _look_for_role_files(basedir, role):


### PR DESCRIPTION
My `ansible` directory has the following format:
```
$ tree -L 1 ansible/
ansible/
|-- ansible.cfg
|-- environments
|-- inventory
|-- jobs
|-- plugins
|-- roles
`-- rules
```

My playbooks are put in the `environments` directory.
I use the `ANSIBLE_ROLES_PATH` variable to change the behaviour of `ansible`.

`ansible-lint` should use the same variable.
The code is taken from https://github.com/ansible/ansible/blob/release1.8.1/lib/ansible/playbook/play.py#L191-L207