### PR TITLE
Remove cp from CommandsInsteadOfModulesRule

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -32,9 +32,9 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
 
     _commands = ['command', 'shell', 'raw']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url', 'wget': 'get_url',
-                'svn': 'subversion', 'cp': 'copy', 'service': 'service',
-                'mount': 'mount', 'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',
-                'unzip': 'unarchive', 'tar': 'unarchive'}
+                'svn': 'subversion', 'service': 'service', 'mount': 'mount',
+                'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get', 'unzip':
+                'unarchive', 'tar': 'unarchive'}
 
     def matchtask(self, file, task):
         if task["action"]["module"] in self._commands:

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ansiblelint.utils
 import os
 from ansiblelint import AnsibleLintRule
 
@@ -33,7 +32,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     _commands = ['command', 'shell', 'raw']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url', 'wget': 'get_url',
                 'svn': 'subversion', 'service': 'service', 'mount': 'mount',
-                'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get', 
+                'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',
                 'unzip': 'unarchive', 'tar': 'unarchive'}
 
     def matchtask(self, file, task):

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -33,8 +33,8 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     _commands = ['command', 'shell', 'raw']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url', 'wget': 'get_url',
                 'svn': 'subversion', 'service': 'service', 'mount': 'mount',
-                'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get', 'unzip':
-                'unarchive', 'tar': 'unarchive'}
+                'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get', 
+                'unzip': 'unarchive', 'tar': 'unarchive'}
 
     def matchtask(self, file, task):
         if task["action"]["module"] in self._commands:


### PR DESCRIPTION
Ansible's copy module is not analagous to the cp command.

Copy's description is:

    The copy module copies a file on the local box to remote locations. Use
    the fetch module to copy files from remote locations to the local box.

Running 'command: cp', however, is used to copy a file within a remote
system, which copy does not actually support.

I don't think there is a valid case to suggest using 'copy' in lieu of
'command: cp'.