### PR TITLE
Do not suggest a command when using the raw module

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -30,7 +30,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
                   'is generally a bad idea'
     tags = ['resources']
 
-    _commands = ['command', 'shell', 'raw']
+    _commands = ['command', 'shell']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url', 'wget': 'get_url',
                 'svn': 'subversion', 'cp': 'copy', 'service': 'service',
                 'mount': 'mount', 'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',


### PR DESCRIPTION
According to http://docs.ansible.com/raw_module.html, the raw module has
two purposes:

    - Installing python-simplejson in old python installations
    - Installing python or using ansible without python

Consider the following valid task (which currently fails lint):

    - name: Install python-simplejson
      raw: yum install python-simplejson -y

For these reasons, the raw module should probably be ignored.