### PR TITLE
Fix unicode text in a task causing an AssertionError while parsing

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -186,7 +186,7 @@ def normalize_task(task):
             else:
                 result[k] = v
         else:
-            if isinstance(v, str):
+            if isinstance(v, basestring):
                 v = _kv_to_dict(k + ' ' + v)
             elif not v:
                 v = dict(module=k)


### PR DESCRIPTION
I had a non-breaking space in one of my tasks. Ironically, it broke ansible-lint.

As it turns out, the yaml parser used returns a unicode object if there's any unicode characters in a key or a value, not a str one. Pretty easy to fix.

Note that my non-breaking space was there erroneously (in fact, I had 8 spread over my playbook, the OS X keyboard layout makes it too easy to accidentally type one after braces or similar special characters.) It might be worth it to check for unicode characters in the playbook as part of the linting process?