### PR TITLE
Fix searching the wrong path when encountering dependent roles

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -141,9 +141,10 @@ def _rolepath(basedir, role):
         # if included from a playbook
         ansible.utils.path_dwim(basedir, os.path.join('roles', role)),
         ansible.utils.path_dwim(basedir, role),
-        # if included from roles/meta/main.yml
-        ansible.utils.path_dwim(basedir,
-                                os.path.join('..', '..', 'roles', role))
+        # if included from roles/[role]/meta/main.yml
+        ansible.utils.path_dwim(
+            basedir, os.path.join('..', '..', '..', 'roles', role)
+        ),
     ]
 
     if C.DEFAULT_ROLES_PATH:


### PR DESCRIPTION
Code should be pretty self-explanatory. Though, before merging, please confirm that `roles/meta/main.yml` is not a possible case here at all, I haven't heard of any such directory structure, but I might be wrong of course.