### PR TITLE
Ensure role_path is defined in _look_for_role_files

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -31,6 +31,7 @@ from yaml.constructor import Constructor
 
 LINE_NUMBER_KEY = '__line__'
 
+
 def load_plugins(directory):
     result = []
     fh = None
@@ -163,9 +164,11 @@ def _rolepath(basedir, role):
 def _look_for_role_files(basedir, role):
     results = []
     for th in ['tasks', 'handlers', 'meta']:
-        thpath = os.path.join(_rolepath(basedir, role), th, 'main.yml')
-        if os.path.exists(thpath):
-            results.append({'path': thpath, 'type': th})
+        role_path = _rolepath(basedir, role)
+        if role_path:
+            thpath = os.path.join(role_path, th, 'main.yml')
+            if os.path.exists(thpath):
+                results.append({'path': thpath, 'type': th})
     return results
 
 
@@ -241,6 +244,7 @@ def get_action_tasks(yaml, file):
                     tasks.extend(block_tasks)
     return [normalize_task(task) for task in tasks
             if 'include' not in task.keys()]
+
 
 def parse_yaml_linenumbers(data):
     """Parses yaml as ansible.utils.parse_yaml but with linenumbers.


### PR DESCRIPTION
The _look_for_role_files method looks for Ansible files
under a possible role_path, as returned by _rolepath().

But this method may return None in some circumstances.

This caused ansible-lint to crash with:
```
  File "ansiblelint/utils.py", line 166, in _look_for_role_files
    thpath = os.path.join(_rolepath(basedir, role), th, 'main.yml')
  File "/usr/lib/python2.7/posixpath.py", line 68, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```
Now we proceed with the files lookup only if role_path is defined.

I hesitated between this and catching the exception, but I decided that this was more explicit. Happy to change either way though.