### PR TITLE
Allow for continuation characters

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -105,6 +105,7 @@ class RulesCollection(object):
         matches = list()
         with open(playbookfile['path'], 'Ur') as f:
             text = f.read()
+        text = text.replace('|\n', '')
         for rule in self.rules:
             if not tags or not set(rule.tags).isdisjoint(tags):
                 if set(rule.tags).isdisjoint(skip_tags):


### PR DESCRIPTION
Ansible allows | at the end of a line to indicate that the next
line is a continuation. Current checks for matching brackets
break if you use this because lint considers each line
separately.