### PR TITLE
Add 'legacy' tag for tests

### DIFF
--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -72,6 +72,9 @@ def main(args):
         parser.print_help(file=sys.stderr)
         return 1
 
+    if 'legacy' not in options.tags:
+        options.skip_tags.append('legacy')
+
     rulesdirs = options.rulesdir or default_rulesdir
 
     rules = RulesCollection()

--- a/lib/ansiblelint/rules/DeprecatedTemplateBracketsRule.py
+++ b/lib/ansiblelint/rules/DeprecatedTemplateBracketsRule.py
@@ -27,7 +27,7 @@ class DeprecatedTemplateBracketsRule(AnsibleLintRule):
     description = 'Checks for old style ${var} ' + \
                   'rather than {{var}}'
 
-    tags = ['deprecation']
+    tags = ['deprecation', 'legacy']
 
     def match(self, file, line):
         return "${" in line


### PR DESCRIPTION
'legacy' tag marks rules that have no longer sense in recent Ansible
code. I.e. using constructs checked by the rule is syntactically wrong
in recent version of Ansible.

'legacy' is like a regular tags, but it is enabled by default.
If needed it can be enable using the -t option.

ANSIBLE0001 (DeprecatedTemplateBracketsRule) is tagged 'legacy'.