### PR TITLE
Support paths with spaces

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -148,7 +148,9 @@ def _rolepath(basedir, role):
         ansible.utils.path_dwim(basedir, role),
         # if included from roles/meta/main.yml
         ansible.utils.path_dwim(basedir,
-                                os.path.join('..', '..', 'roles', role))
+                                os.path.join('..', '..', 'roles', role)),
+        ansible.utils.path_dwim(basedir,
+                                os.path.join('..', '..', role))
     ]
 
     if C.DEFAULT_ROLES_PATH:

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -22,9 +22,9 @@ import os
 import glob
 import imp
 import ansible.utils
-import shlex
 from ansible.playbook.task import Task
 import ansible.constants as C
+from ansible.module_utils.splitter import split_args
 import yaml
 from yaml.composer import Composer
 from yaml.constructor import Constructor
@@ -89,7 +89,12 @@ def find_children(playbook):
         for child in play_children(basedir, item, playbook[1]):
             if "$" in child['path'] or "{{" in child['path']:
                 continue
-            path = shlex.split(child['path'])[0]  # strip tags=smsng
+            valid_tokens = list()
+            for token in split_args(child['path']):
+                if '=' in token:
+                    break
+                valid_tokens.append(token)
+            path = ' '.join(valid_tokens)
             results.append({
                 'path': ansible.utils.path_dwim(basedir, path),
                 'type': child['type']

--- a/test/TestTaskIncludes.py
+++ b/test/TestTaskIncludes.py
@@ -14,4 +14,4 @@ class TestTaskIncludes(unittest.TestCase):
         filename = 'test/taskincludes.txt'
         runner = ansiblelint.Runner(self.rules, {filename}, [], [])
         runner.run()
-        self.assertEqual(len(runner.playbooks), 3)
+        self.assertEqual(len(runner.playbooks), 4)

--- a/test/directory with spaces/main.txt
+++ b/test/directory with spaces/main.txt
@@ -1,0 +1,1 @@
+- debug: msg="tasks in directory with spaces included"

--- a/test/taskincludes.txt
+++ b/test/taskincludes.txt
@@ -6,3 +6,4 @@
     - include: nestedincludes.txt tags=nested
     - include: "{{ varnotset }}.txt"
     - include: "{{ varset }}.txt"
+    - include: "directory with spaces/main.txt"


### PR DESCRIPTION
Fixes #62

Use `ansible.module_utils.splitter.split_args` to parse the `include` instruction as it's done in ansible.
https://github.com/ansible/ansible/blob/5ce3988d8693357f671f3fbec43b2d3b862db5f6/v1/ansible/playbook/__init__.py#L210

Take all the tokens without an `=` to build the path.