### PR TITLE
Tasks/py cleanup

### DIFF
--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -20,14 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ansiblelint.utils as utils
-import ansiblelint.formatters as formatters
-from ansiblelint import RulesCollection
-import ansiblelint
+from __future__ import print_function
+
 import errno
+import optparse
 import os
 import sys
-import optparse
+
+import ansiblelint
+import ansiblelint.formatters as formatters
+from ansiblelint import RulesCollection
+import ansiblelint.utils as utils
 from ansiblelint.version import __version__
 
 
@@ -79,11 +82,11 @@ def main(args):
         rules.extend(RulesCollection.create_from_directory(rulesdir))
 
     if options.listrules:
-        print rules
+        print(rules)
         return 0
 
     if options.listtags:
-        print rules.listtags()
+        print(rules.listtags())
         return 0
 
     if isinstance(options.tags, basestring):
@@ -97,7 +100,7 @@ def main(args):
     matches = runner.run()
 
     for match in matches:
-        print formatter.format(match)
+        print(formatter.format(match))
 
     if len(matches):
         return 2

--- a/examples/rules/TaskHasTag.py
+++ b/examples/rules/TaskHasTag.py
@@ -1,12 +1,11 @@
-import ansiblelint.utils
 from ansiblelint import AnsibleLintRule
+
 
 class TaskHasTag(AnsibleLintRule):
     id = 'EXAMPLE001'
     shortdesc = 'Tasks must have tag'
     description = 'Tasks must have tag'
     tags = ['productivity', 'tags']
-
 
     def matchtask(self, file, task):
         # The meta files don't have tags
@@ -18,12 +17,11 @@ class TaskHasTag(AnsibleLintRule):
 
         # If the task include another task or make the playbook fail
         # Don't force to have a tag
-        if not set(task.keys()).isdisjoint(['include','fail']):
+        if not set(task.keys()).isdisjoint(['include', 'fail']):
             return False
 
         # Task should have tags
-        if not task.has_key('tags'):
-              return True
+        if 'tags' not in task:
+            return True
 
         return False
-

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -135,7 +135,7 @@ class RulesCollection(object):
         return result
 
 
-class Match:
+class Match(object):
 
     def __init__(self, linenumber, line, filename, rule, message=None):
         self.linenumber = linenumber
@@ -150,7 +150,7 @@ class Match:
                                 self.filename, self.linenumber, self.line)
 
 
-class Runner:
+class Runner(object):
 
     def __init__(self, rules, playbooks, tags, skip_tags):
         self.rules = rules

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -38,7 +38,8 @@ class AnsibleLintRule(object):
     def verbose(self):
         return self.id + ": " + self.shortdesc + "\n  " + self.description
 
-    def match(self, ansiblefile="", line=""):
+    def match(self, ansiblefile, line):
+        del ansiblefile, line
         return []
 
     def matchlines(self, ansiblefile, text):
@@ -56,9 +57,11 @@ class AnsibleLintRule(object):
         return matches
 
     def matchplay(self, ansiblefile, play):
+        del ansiblefile, play
         return []
 
-    def matchtask(self, ansiblefile="", task=None):
+    def matchtask(self, ansiblefile, task):
+        del ansiblefile, task
         return []
 
     def matchtasks(self, ansiblefile, text):

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,4 +1,4 @@
-class Formatter:
+class Formatter(object):
 
     def format(self, match):
         formatstr = "[{0}] {1}\n{2}:{3}\n{4}\n"
@@ -9,7 +9,7 @@ class Formatter:
                                 match.line)
 
 
-class QuietFormatter:
+class QuietFormatter(object):
 
     def format(self, match):
         formatstr = "[{0}] {1}:{2}"
@@ -17,7 +17,7 @@ class QuietFormatter:
                                 match.linenumber)
 
 
-class ParseableFormatter:
+class ParseableFormatter(object):
 
     def format(self, match):
         formatstr = "{0}:{1}: [{2}] {3}"

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -18,8 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ansiblelint.utils
 import os
+
 from ansiblelint import AnsibleLintRule
 
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -35,7 +35,7 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
                   'ln': 'state=link', 'mkdir': 'state=directory',
                   'rmdir': 'state=absent', 'rm': 'state=absent'}
 
-    def matchtask(self, file, task):
+    def matchtask(self, _, task):
         if task["action"]["module"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._arguments:

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -24,16 +24,19 @@ from ansiblelint import AnsibleLintRule
 
 
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
-    id = 'ANSIBLE0007'
-    shortdesc = 'Using command rather than an argument to e.g. file'
-    description = 'Executing a command when there are arguments to modules ' + \
-                  'is generally a bad idea'
-    tags = ['resources']
-
     _commands = ['command', 'shell', 'raw']
     _arguments = {'chown': 'owner', 'chmod': 'mode', 'chgrp': 'group',
                   'ln': 'state=link', 'mkdir': 'state=directory',
                   'rmdir': 'state=absent', 'rm': 'state=absent'}
+
+    def __init__(self):
+        super(CommandsInsteadOfArgumentsRule, self).__init__()
+
+        self.id = 'ANSIBLE0007'
+        self.shortdesc = 'Using command rather than an argument to e.g. file'
+        self.description = 'Executing a command when there are arguments to modules ' + \
+                           'is generally a bad idea'
+        self.tags = ['resources']
 
     def matchtask(self, ansiblefile, task):
         del ansiblefile

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -26,7 +26,7 @@ from ansiblelint import AnsibleLintRule
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
     id = 'ANSIBLE0007'
     shortdesc = 'Using command rather than an argument to e.g. file'
-    description = 'Executing a command when there is are arguments to modules ' + \
+    description = 'Executing a command when there are arguments to modules ' + \
                   'is generally a bad idea'
     tags = ['resources']
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -35,7 +35,9 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
                   'ln': 'state=link', 'mkdir': 'state=directory',
                   'rmdir': 'state=absent', 'rm': 'state=absent'}
 
-    def matchtask(self, _, task):
+    def matchtask(self, ansiblefile, task):
+        del ansiblefile
+
         if task["action"]["module"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._arguments:

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 import os
+
 from ansiblelint import AnsibleLintRule
 
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -24,17 +24,20 @@ from ansiblelint import AnsibleLintRule
 
 
 class CommandsInsteadOfModulesRule(AnsibleLintRule):
-    id = 'ANSIBLE0006'
-    shortdesc = 'Using command rather than module'
-    description = 'Executing a command when there is an Ansible module ' + \
-                  'is generally a bad idea'
-    tags = ['resources']
-
     _commands = ['command', 'shell']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url', 'wget': 'get_url',
                 'svn': 'subversion', 'service': 'service', 'mount': 'mount',
                 'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',
                 'unzip': 'unarchive', 'tar': 'unarchive'}
+
+    def __init__(self):
+        super(CommandsInsteadOfModulesRule, self).__init__()
+
+        self.id = 'ANSIBLE0006'
+        self.shortdesc = 'Using command rather than module'
+        self.description = 'Executing a command when there is an Ansible module ' + \
+                           'is generally a bad idea'
+        self.tags = ['resources']
 
     def matchtask(self, ansiblefile, task):
         del ansiblefile

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -36,7 +36,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
                 'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',
                 'unzip': 'unarchive', 'tar': 'unarchive'}
 
-    def matchtask(self, file, task):
+    def matchtask(self, _, task):
         if task["action"]["module"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._modules:

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -36,7 +36,9 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
                 'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',
                 'unzip': 'unarchive', 'tar': 'unarchive'}
 
-    def matchtask(self, _, task):
+    def matchtask(self, ansiblefile, task):
+        del ansiblefile
+
         if task["action"]["module"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._modules:

--- a/lib/ansiblelint/rules/DeprecatedTemplateBracketsRule.py
+++ b/lib/ansiblelint/rules/DeprecatedTemplateBracketsRule.py
@@ -22,11 +22,13 @@ from ansiblelint import AnsibleLintRule
 
 
 class DeprecatedTemplateBracketsRule(AnsibleLintRule):
-    id = 'ANSIBLE0001'
-    shortdesc = 'Old style (${var}) brackets'
-    description = 'Checks for old style ${var} rather than {{var}}'
+    def __init__(self):
+        super(DeprecatedTemplateBracketsRule, self).__init__()
 
-    tags = ['deprecation']
+        self.id = 'ANSIBLE0001'
+        self.shortdesc = 'Old style (${var}) brackets'
+        self.description = 'Checks for old style ${var} rather than {{var}}'
+        self.tags = ['deprecation']
 
     def match(self, _, line):
         return "${" in line

--- a/lib/ansiblelint/rules/DeprecatedTemplateBracketsRule.py
+++ b/lib/ansiblelint/rules/DeprecatedTemplateBracketsRule.py
@@ -24,10 +24,9 @@ from ansiblelint import AnsibleLintRule
 class DeprecatedTemplateBracketsRule(AnsibleLintRule):
     id = 'ANSIBLE0001'
     shortdesc = 'Old style (${var}) brackets'
-    description = 'Checks for old style ${var} ' + \
-                  'rather than {{var}}'
+    description = 'Checks for old style ${var} rather than {{var}}'
 
     tags = ['deprecation']
 
-    def match(self, file, line):
+    def match(self, _, line):
         return "${" in line

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -22,11 +22,14 @@ from ansiblelint import AnsibleLintRule
 
 
 class GitHasVersionRule(AnsibleLintRule):
-    id = 'ANSIBLE0004'
-    shortdesc = 'Git checkouts must contain explicit version'
-    description = 'All version control checkouts must point to ' + \
-                  'an explicit commit or tag, not just "latest"'
-    tags = ['repeatability']
+    def __init__(self):
+        super(GitHasVersionRule, self).__init__()
+
+        self.id = 'ANSIBLE0004'
+        self.shortdesc = 'Git checkouts must contain explicit version'
+        self.description = 'All version control checkouts must point to ' + \
+                           'an explicit commit or tag, not just "latest"'
+        self.tags = ['repeatability']
 
     def matchtask(self, ansiblefile, task):
         del ansiblefile

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -28,6 +28,8 @@ class GitHasVersionRule(AnsibleLintRule):
                   'an explicit commit or tag, not just "latest"'
     tags = ['repeatability']
 
-    def matchtask(self, _, task):
+    def matchtask(self, ansiblefile, task):
+        del ansiblefile
+
         return (task['action']['module'] == 'git' and
                 task['action'].get('version', 'HEAD') == 'HEAD')

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ansiblelint.utils
 from ansiblelint import AnsibleLintRule
 
 

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -28,5 +28,6 @@ class GitHasVersionRule(AnsibleLintRule):
                   'an explicit commit or tag, not just "latest"'
     tags = ['repeatability']
 
-    def matchtask(self, file, task):
-        return (task['action']['module'] == 'git' and task['action'].get('version', 'HEAD') == 'HEAD')
+    def matchtask(self, _, task):
+        return (task['action']['module'] == 'git' and
+                task['action'].get('version', 'HEAD') == 'HEAD')

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -22,12 +22,14 @@ from ansiblelint import AnsibleLintRule
 
 
 class MercurialHasRevisionRule(AnsibleLintRule):
-    id = 'ANSIBLE0005'
-    shortdesc = 'Mercurial checkouts must contain explicit revision'
-    description = 'All version control checkouts must point to ' + \
-                  'an explicit commit or tag, not just "latest"'
+    def __init__(self):
+        super(MercurialHasRevisionRule, self).__init__()
 
-    tags = ['repeatability']
+        self.id = 'ANSIBLE0005'
+        self.shortdesc = 'Mercurial checkouts must contain explicit revision'
+        self.description = 'All version control checkouts must point to ' + \
+                      'an explicit commit or tag, not just "latest"'
+        self.tags = ['repeatability']
 
     def matchtask(self, ansiblefile, task):
         del ansiblefile

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -29,5 +29,6 @@ class MercurialHasRevisionRule(AnsibleLintRule):
 
     tags = ['repeatability']
 
-    def matchtask(self, file, task):
-        return task['action']['module'] == 'hg' and task['action'].get('revision', 'default') == 'default'
+    def matchtask(self, _, task):
+        return (task['action']['module'] == 'hg' and
+                task['action'].get('revision', 'default') == 'default')

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ansiblelint.utils
 from ansiblelint import AnsibleLintRule
 
 

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -29,6 +29,8 @@ class MercurialHasRevisionRule(AnsibleLintRule):
 
     tags = ['repeatability']
 
-    def matchtask(self, _, task):
+    def matchtask(self, ansiblefile, task):
+        del ansiblefile
+
         return (task['action']['module'] == 'hg' and
                 task['action'].get('revision', 'default') == 'default')

--- a/lib/ansiblelint/rules/MismatchedBracketRule.py
+++ b/lib/ansiblelint/rules/MismatchedBracketRule.py
@@ -28,5 +28,5 @@ class MismatchedBracketRule(AnsibleLintRule):
                   'versa then templating can fail nastily'
     tags = ['templating']
 
-    def match(self, file, line):
+    def match(self, _, line):
         return line.count("{") != line.count("}")

--- a/lib/ansiblelint/rules/MismatchedBracketRule.py
+++ b/lib/ansiblelint/rules/MismatchedBracketRule.py
@@ -22,11 +22,14 @@ from ansiblelint import AnsibleLintRule
 
 
 class MismatchedBracketRule(AnsibleLintRule):
-    id = 'ANSIBLE0003'
-    shortdesc = 'Mismatched { and }'
-    description = 'If lines contain more { than } or vice ' + \
-                  'versa then templating can fail nastily'
-    tags = ['templating']
+    def __init__(self):
+        super(MismatchedBracketRule, self).__init__()
+
+        self.id = 'ANSIBLE0003'
+        self.shortdesc = 'Mismatched { and }'
+        self.description = 'If lines contain more { than } or vice ' + \
+                      'versa then templating can fail nastily'
+        self.tags = ['templating']
 
     def match(self, _, line):
         return line.count("{") != line.count("}")

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -27,5 +27,5 @@ class TrailingWhitespaceRule(AnsibleLintRule):
     description = 'There should not be any trailing whitespace'
     tags = ['formatting']
 
-    def match(self, file, line):
+    def match(self, _, line):
         return line.rstrip() != line

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -22,10 +22,13 @@ from ansiblelint import AnsibleLintRule
 
 
 class TrailingWhitespaceRule(AnsibleLintRule):
-    id = 'ANSIBLE0002'
-    shortdesc = 'Trailing whitespace'
-    description = 'There should not be any trailing whitespace'
-    tags = ['formatting']
+    def __init__(self):
+        super(TrailingWhitespaceRule, self).__init__()
+
+        self.id = 'ANSIBLE0002'
+        self.shortdesc = 'Trailing whitespace'
+        self.description = 'There should not be any trailing whitespace'
+        self.tags = ['formatting']
 
     def match(self, ansiblefile, line):
         del ansiblefile

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -27,5 +27,7 @@ class TrailingWhitespaceRule(AnsibleLintRule):
     description = 'There should not be any trailing whitespace'
     tags = ['formatting']
 
-    def match(self, _, line):
+    def match(self, ansiblefile, line):
+        del ansiblefile
+
         return line.rstrip() != line

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -121,17 +121,20 @@ def play_children(basedir, item, parent_type):
     return []
 
 
-def _include_children(basedir, k, v, parent_type):
+def _include_children(basedir, _, v, parent_type):
     return [{'path': ansible.utils.path_dwim(basedir, v), 'type': parent_type}]
 
 
 def _taskshandlers_children(basedir, k, v, parent_type):
+    del k, parent_type
     return [{'path': ansible.utils.path_dwim(basedir, th['include']),
              'type': 'tasks'}
             for th in v if 'include' in th]
 
 
 def _roles_children(basedir, k, v, parent_type):
+    del k, parent_type
+
     results = []
     for role in v:
         if isinstance(role, dict):
@@ -156,7 +159,7 @@ def _rolepath(basedir, role):
                                 os.path.join('..', '..', role))
     ]
 
-    if C.DEFAULT_ROLES_PATH:
+    if C.DEFAULT_ROLES_PATH != "":
         search_locations = C.DEFAULT_ROLES_PATH.split(os.pathsep)
         for loc in search_locations:
             loc = os.path.expanduser(loc)
@@ -246,12 +249,12 @@ def task_to_str(task):
     return "{0} {1}".format(action["module"], args)
 
 
-def get_action_tasks(yaml, file):
+def get_action_tasks(yamldata, yamlfile):
     tasks = []
-    if file['type'] in ['tasks', 'handlers']:
-        tasks = yaml
+    if yamlfile['type'] in ['tasks', 'handlers']:
+        tasks = yamldata
     else:
-        for block in yaml:
+        for block in yamldata:
             for section in ['tasks', 'handlers', 'pre_tasks', 'post_tasks']:
                 if section in block:
                     block_tasks = block.get(section) or []

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -18,16 +18,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import os
 import glob
 import imp
-import ansible.utils
-from ansible.playbook.task import Task
-import ansible.constants as C
-from ansible.module_utils.splitter import split_args
+import os
+
 import yaml
 from yaml.composer import Composer
 from yaml.constructor import Constructor
+
+import ansible.constants as C
+from ansible.module_utils.splitter import split_args
+from ansible.playbook.task import Task
+import ansible.utils
+
 
 LINE_NUMBER_KEY = '__line__'
 
@@ -51,7 +54,6 @@ def load_plugins(directory):
 
 
 def tokenize(line):
-    result = list()
     tokens = line.lstrip().split(" ")
     if tokens[0] == '-':
         tokens = tokens[1:]
@@ -195,8 +197,11 @@ def _kv_to_dict(v):
 
 
 def normalize_task(task):
-    ''' ensures that all tasks have an action key
-        and that string values are converted to python objects '''
+    """Normalize task action key and values.
+
+    Ensures that all tasks have an action key and that string values are
+    converted to python objects.
+    """
 
     result = dict()
     for (k, v) in task.items():
@@ -259,7 +264,8 @@ def get_action_tasks(yaml, file):
 def parse_yaml_linenumbers(data):
     """Parses yaml as ansible.utils.parse_yaml but with linenumbers.
 
-    The line numbers are stored in each node's LINE_NUMBER_KEY key"""
+    The line numbers are stored in each node's LINE_NUMBER_KEY key.
+    """
     loader = yaml.Loader(data)
 
     def compose_node(parent, index):

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=missing-docstring,no-self-use,too-few-public-methods,bad-continuation,too-many-arguments,invalid-name

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ description-file = README.md
 [flake8]
 max-line-length = 120
 exclude = setup.py,build/*,test/*,venv/*
+
+[nosetests]
+with-coverage = true
+cover-package = ansiblelint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.md
+
+[flake8]
+max-line-length = 120
+exclude = setup.py,build/*,test/*,venv/*

--- a/test/TestLintRule.py
+++ b/test/TestLintRule.py
@@ -44,3 +44,4 @@ class TestRule(unittest.TestCase):
         rule = UnsetVariableMatcherRule.UnsetVariableMatcherRule()
         matches = rule.matchlines(dict(path=filename, type='playbooks'), text)
         self.assertEqual(len(matches), 2)
+        self.assertEqual(matches[0].rule.id, 'TEST0002')

--- a/test/rules/EMatcherRule.py
+++ b/test/rules/EMatcherRule.py
@@ -2,11 +2,14 @@ import ansiblelint.utils
 from ansiblelint import AnsibleLintRule
 
 class EMatcherRule(AnsibleLintRule):
-    id = 'TEST0001'
-    description = 'This is a test rule that looks for lines ' + \
-                  'containing the letter e'
-    shortdesc = 'The letter "e" is present'
-    tags = {'fake', 'dummy', 'test1'}
+    def __init__(self):
+        super(EMatcherRule, self).__init__()
+
+        self.id = 'TEST0001'
+        self.description = 'This is a test rule that looks for lines ' + \
+                           'containing the letter e'
+        self.shortdesc = 'The letter "e" is present'
+        self.tags = {'fake', 'dummy', 'test1'}
 
     def match(self, filename, line):
-        return "e" in line 
+        return "e" in line

--- a/test/rules/UnsetVariableMatcherRule.py
+++ b/test/rules/UnsetVariableMatcherRule.py
@@ -2,11 +2,14 @@ import ansiblelint.utils
 from ansiblelint import AnsibleLintRule
 
 class UnsetVariableMatcherRule(AnsibleLintRule):
-    id = 'TEST0002'
-    shortdesc = 'Line contains untemplated variable'
-    description = 'This is a test rule that looks for lines ' + \
-                  'post templating that still contain {{'
-    tags = {'fake', 'dummy', 'test2'}
+    def __init__(self):
+        super(UnsetVariableMatcherRule, self).__init__()
+
+        self.id = 'TEST0002'
+        self.shortdesc = 'Line contains untemplated variable'
+        self.description = 'This is a test rule that looks for lines ' + \
+                           'post templating that still contain {{'
+        self.tags = {'fake', 'dummy', 'test2'}
 
     def match(self,filename,line):
         return "{{" in line


### PR DESCRIPTION
Runs on Py3.4. 
flake8/pep8 cleanups. Allowed for longer lines.
General Python cleanups. [] v. list() etc.

Removed code like the following

```
def foo(arg1, arg2=set()):
    pass
```

leads to nasty bugs. http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments has details.

This is like @kovacsbalu's pull request but I think mine has more changes.