### PR TITLE
Add --exclude-paths to ansible-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,22 @@ Usage
 Usage: ansible-lint playbook.yml
 
 Options:
-  --version     show program's version number and exit
-  -h, --help    show this help message and exit
-  -L            list all the rules
-  -q            quieter, although not silent output
-  -r RULESDIR   location of rules directory
-  -t TAGS       only check rules tagged with these values
-  -T            list all the tags
-  -x SKIP_LIST  only check rules whose id/tags do not match these values
+  --version             show program's version number and exit
+  -h, --help            show this help message and exit
+  -L                    list all the rules
+  -q                    quieter, although not silent output
+  -p                    parseable output in the format of pep8
+  -r RULESDIR           add one or more rules directories using one or more -r
+                        arguments. Defaults to ['/Users/icordasc/sandbox
+                        /ansible-lint/lib/ansiblelint/rules'] but any -r flags
+                        completely override this.
+  -t TAGS               only check rules tagged with these values
+  -T                    list all the tags
+  -x SKIP_LIST          only check rules whose id/tags do not match these
+                        values
+  --exclude=EXCLUDE_PATHS
+                        path to directories or files to skip. This option is
+                        repeatable.
 ```
 
 Rules

--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -60,6 +60,9 @@ def main(args):
     parser.add_option('-x', dest='skip_list', default=[],
                       help="only check rules whose id/tags do not " +
                       "match these values")
+    parser.add_option('--exclude', dest='exclude_paths', action='append',
+                      help='path to directories or files to skip. This option'
+                           ' is repeatable.')
     options, args = parser.parse_args(args)
 
     if options.quiet:
@@ -93,7 +96,7 @@ def main(args):
 
     playbooks = set(args)
     runner = ansiblelint.Runner(rules, playbooks, options.tags,
-                                options.skip_list)
+                                options.skip_list, options.exclude_paths)
     matches = runner.run()
 
     for match in matches:

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -33,10 +33,16 @@ class TestRule(unittest.TestCase):
 
     def test_runner_count(self):
         filename = 'test/nomatchestest.txt'
-        runner = ansiblelint.Runner(self.rules, {filename}, [], [])
+        runner = ansiblelint.Runner(self.rules, {filename}, [], [], [])
         assert (len(runner.run()) == 0)
 
     def test_unicode_runner_count(self):
         filename = 'test/unicode.txt'
-        runner = ansiblelint.Runner(self.rules, {filename}, [], [])
+        runner = ansiblelint.Runner(self.rules, {filename}, [], [], [])
+        assert (len(runner.run()) == 0)
+
+    def test_runner_excludes_paths(self):
+        files = {'test/unicode.txt', 'examples/lots_of_warnings.yml'}
+        excludes = ['examples/lots_of_warnings.yml']
+        runner = ansiblelint.Runner(self.rules, files, [], [], excludes)
         assert (len(runner.run()) == 0)

--- a/test/TestSkippedTasks.py
+++ b/test/TestSkippedTasks.py
@@ -34,5 +34,5 @@ class TestRule(unittest.TestCase):
 
     def test_runner_count(self):
         filename = 'test/skiptasks.txt'
-        runner = ansiblelint.Runner(self.rules, {filename}, [], [])
+        runner = ansiblelint.Runner(self.rules, {filename}, [], [], [])
         self.assertEqual(len(runner.run()), 4)

--- a/test/TestTaskIncludes.py
+++ b/test/TestTaskIncludes.py
@@ -12,6 +12,6 @@ class TestTaskIncludes(unittest.TestCase):
 
     def test_included_tasks(self):
         filename = 'test/taskincludes.txt'
-        runner = ansiblelint.Runner(self.rules, {filename}, [], [])
+        runner = ansiblelint.Runner(self.rules, {filename}, [], [], [])
         runner.run()
         self.assertEqual(len(runner.playbooks), 4)


### PR DESCRIPTION
This allows users to specify a list of paths they want to exclude from
being checked.

Example usage:

```
$ ansible-lint --exclude-paths examples/lots_of_warnings.yml \
    examples/*.yml
```

Closes #80