### PR TITLE
Allow snake_case module names for rules

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -57,6 +57,16 @@ VALID_KEYS = [
 ]
 
 
+def detect_classname(pluginname):
+    # ansible-lint prefers CamelCase.py containing "class CamelCase"
+    if pluginname[0].isupper():
+        return pluginname
+
+    # python standard is snake_case.py containing "class SnakeCase"
+    # https://www.python.org/dev/peps/pep-0008/#package-and-module-names
+    return "".join(x.title() for x in pluginname.split('_'))
+
+
 def load_plugins(directory):
     result = []
     fh = None
@@ -67,7 +77,8 @@ def load_plugins(directory):
         try:
             fh, filename, desc = imp.find_module(pluginname, [directory])
             mod = imp.load_module(pluginname, fh, filename, desc)
-            obj = getattr(mod, pluginname)()
+            classname = detect_classname(pluginname)
+            obj = getattr(mod, classname)()
             result.append(obj)
         finally:
             if fh:

--- a/test/TestSnakeCaseRule.py
+++ b/test/TestSnakeCaseRule.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest
+
+from ansiblelint import RulesCollection
+
+
+class TestSnakeCaseRule(unittest.TestCase):
+    def test_snake_case_rule(self):
+        RulesCollection.create_from_directory('./test/snake_case_rule')

--- a/test/snake_case_rule/snake_case_rule.py
+++ b/test/snake_case_rule/snake_case_rule.py
@@ -1,0 +1,11 @@
+from ansiblelint import AnsibleLintRule
+
+
+class SnakeCaseRule(AnsibleLintRule):
+    id = 'SNAKE001'
+    description = 'This is a test rule with a snake_case filename'
+    shortdesc = 'snake_case'
+    tags = {'fake', 'dummy', 'test1'}
+
+    def match(self, filename, line):
+        return True


### PR DESCRIPTION
PEP8 states that modules (files) should be named with snake_case not
CamelCase. Following this convention for AnsibleLint rules causes a
traceback:

```
Traceback (most recent call last):
  File "ansible-lint", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "bin/ansible-lint", line 110, in <module>
    sys.exit(main(sys.argv[1:]))
  File "bin/ansible-lint", line 79, in main
    rules.extend(RulesCollection.create_from_directory(rulesdir))
  File "lib/ansiblelint/__init__.py", line 136, in create_from_directory
    result.rules = ansiblelint.utils.load_plugins(os.path.expanduser(rulesdir))
  File "lib/ansiblelint/utils.py", line 45, in load_plugins
    obj = getattr(mod, pluginname)()
AttributeError: 'module' object has no attribute 'task_has_tag'
```

This patch checks the initial capitalisation of the module name, if it's
lowercase then the module name is converted to CamelCase before
attempting to load that class.
