### PR TITLE
Refactor MismatchedBracketRule to inspect parsed YAML instead of raw …

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -77,9 +77,15 @@ class AnsibleLintRule(object):
             for play in yaml:
                 result = self.matchplay(file, play)
                 if result:
-                    (section, message) = result
-                    matches.append(Match(play[ansiblelint.utils.LINE_NUMBER_KEY], section,
-                                   file['path'], self, message))
+                    if isinstance(result, tuple):
+                        result = [result]
+
+                    if not isinstance(result, list):
+                        raise Exception("{} is not a list".format(result))
+
+                    for section, message in result:
+                        matches.append(Match(play[ansiblelint.utils.LINE_NUMBER_KEY],
+                                             section, file['path'], self, message))
         return matches
 
 

--- a/lib/ansiblelint/rules/MismatchedBracketRule.py
+++ b/lib/ansiblelint/rules/MismatchedBracketRule.py
@@ -28,5 +28,27 @@ class MismatchedBracketRule(AnsibleLintRule):
                   'versa then templating can fail nastily'
     tags = ['templating']
 
-    def match(self, file, line):
-        return line.count("{") != line.count("}")
+    def _check_value(self, v):
+        results = []
+
+        if isinstance(v, dict):
+            # Transform into a list to simplify processing
+            # since we do not care about the keys
+            v = v.values()
+
+        if isinstance(v, list):
+            for i in v:
+                output = self._check_value(i)
+                if output:
+                    results += output
+        elif isinstance(v, (str, unicode)):
+            if v.count("{") != v.count("}"):
+                results.append((v, "mismatched braces"))
+        else:
+            # not a type we care about
+            pass
+
+        return results
+
+    def matchplay(self, file, play):
+        return self._check_value(play)

--- a/test/TestMismatchedBracketRule.py
+++ b/test/TestMismatchedBracketRule.py
@@ -1,0 +1,79 @@
+import unittest
+
+from ansiblelint.rules.MismatchedBracketRule import MismatchedBracketRule
+import ansiblelint.utils
+
+
+class TestMismatchedBracketRule(unittest.TestCase):
+    simple_dict_yaml = {
+        'value1': '{foo}}',
+        'value2': 2,
+        'value3': ['foo', 'bar', '{baz}}'],
+        'value4': '{bar}',
+        'value5': '{{baz}',
+    }
+
+    def setUp(self):
+        self.rule = MismatchedBracketRule()
+
+    def test_check_value_simple_matching(self):
+        result = self.rule._check_value("{{foo}}")
+        self.assertEquals(0, len(result))
+
+    def test_check_value_simple_not_matching(self):
+        result = self.rule._check_value("{{foo}")
+        self.assertEquals(1, len(result))
+
+    def test_check_value_shallow_dict(self):
+        result = self.rule._check_value(self.simple_dict_yaml)
+        self.assertEquals(3, len(result))
+
+    def test_check_value_nested(self):
+        yaml = [
+            self.simple_dict_yaml,
+            {
+                'values': self.simple_dict_yaml,
+                'more_values': [self.simple_dict_yaml, self.simple_dict_yaml],
+            },
+        ]
+
+        result = self.rule._check_value(yaml)
+        self.assertEquals(12, len(result))
+
+
+class TestMismatchedBracketRuleWithFile(unittest.TestCase):
+    file1 = 'test/bracketsmatchtest.txt'
+    file2 = 'test/multiline-bracketsmatchtest.txt'
+    file3 = 'test/multiline-brackets-do-not-match-test.txt'
+
+    def setUp(self):
+        self.yaml2 = ansiblelint.utils.parse_yaml_linenumbers(open(self.file2).read())
+
+        self.rule = MismatchedBracketRule()
+
+    def test_matchplay_file1(self):
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file1).read())
+
+        self.assertTrue(yaml)
+        for play in yaml:
+            result = self.rule.matchplay(self.file1, play)
+            self.assertEquals(0, len(result))
+
+    def test_matchplay_file2(self):
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file2).read())
+
+        self.assertTrue(yaml)
+        for play in yaml:
+            result = self.rule.matchplay(self.file2, play)
+            self.assertEquals(0, len(result))
+
+    def test_matchplay_file3(self):
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file3).read())
+
+        self.assertEquals(2, len(yaml))
+
+        result = self.rule.matchplay(self.file3, yaml[0])
+        self.assertEquals(1, len(result))
+
+        result = self.rule.matchplay(self.file3, yaml[1])
+        self.assertEquals(1, len(result))

--- a/test/brackets-do-not-match-test.txt
+++ b/test/brackets-do-not-match-test.txt
@@ -1,0 +1,22 @@
+---
+- hosts: foo
+  roles:
+    - ../../../roles/base_os
+    - ../../../roles/repos
+    - {
+        role: ../../../roles/openshift_master,
+        oo_minion_ips: "{ hostvars['localhost'].oo_minion_ips | default(['']) }}",
+        oo_bind_ip: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address | default(['']) }}"
+      }
+    - ../../../roles/pods
+
+- name: "Set Origin specific facts on localhost (for later use)"
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Setting oo_minion_ips fact on localhost
+      set_fact:
+        oo_minion_ips: "{{ hostvars
+            | oo_select_keys(groups['tag_env-host-type-' + oo_env + '-openshift-minion'])
+            | oo_collect(attribute='ansible_eth0.ipv4.address') }"
+      when: groups['tag_env-host-type-' + oo_env + '-openshift-minion'] is defined

--- a/test/multiline-brackets-do-not-match-test.txt
+++ b/test/multiline-brackets-do-not-match-test.txt
@@ -1,0 +1,22 @@
+---
+- hosts: foo
+  roles:
+    - ../../../roles/base_os
+    - ../../../roles/repos
+    - {
+        role: ../../../roles/openshift_master,
+        oo_minion_ips: "{ hostvars['localhost'].oo_minion_ips | default(['']) }}",
+        oo_bind_ip: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address | default(['']) }}"
+      }
+    - ../../../roles/pods
+
+- name: "Set Origin specific facts on localhost (for later use)"
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Setting oo_minion_ips fact on localhost
+      set_fact:
+        oo_minion_ips: "{{ hostvars
+            | oo_select_keys(groups['tag_env-host-type-' + oo_env + '-openshift-minion'])
+            | oo_collect(attribute='ansible_eth0.ipv4.address') }"
+      when: groups['tag_env-host-type-' + oo_env + '-openshift-minion'] is defined

--- a/test/multiline-bracketsmatchtest.txt
+++ b/test/multiline-bracketsmatchtest.txt
@@ -1,0 +1,22 @@
+---
+- hosts: foo
+  roles:
+    - ../../../roles/base_os
+    - ../../../roles/repos
+    - {
+        role: ../../../roles/openshift_master,
+        oo_minion_ips: "{{ hostvars['localhost'].oo_minion_ips | default(['']) }}",
+        oo_bind_ip: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address | default(['']) }}"
+      }
+    - ../../../roles/pods
+
+- name: "Set Origin specific facts on localhost (for later use)"
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Setting oo_minion_ips fact on localhost
+      set_fact:
+        oo_minion_ips: "{{ hostvars
+            | oo_select_keys(groups['tag_env-host-type-' + oo_env + '-openshift-minion'])
+            | oo_collect(attribute='ansible_eth0.ipv4.address') }}"
+      when: groups['tag_env-host-type-' + oo_env + '-openshift-minion'] is defined


### PR DESCRIPTION
…strings

The check is whether the underlying Jinja2 variables can be parsed not whether the YAML
is valid so use the YAML parser to simplify the test.

Added 2 new text files for testing as well as a unit test specifically targeting
MismatchedBraceRule.