### PR TITLE
add sudo rule

### DIFF
--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -1,0 +1,30 @@
+from ansiblelint import AnsibleLintRule
+
+
+class SudoRule(AnsibleLintRule):
+    id = 'ANSIBLE0008'
+    shortdesc = 'Deprecated sudo'
+    description = 'Instead of sudo/sudo_user, use become/become_user.'
+    tags = ['deprecated']
+
+    def _check_value(self, play_frag):
+        results = []
+
+        if isinstance(play_frag, dict):
+            if 'sudo' in play_frag:
+                results.append(({'sudo': play_frag['sudo']},
+                                'deprecated sudo feature'))
+            if 'sudo_user' in play_frag:
+                results.append(({'sudo_user': play_frag['sudo_user']},
+                                'deprecated sudo_user feature'))
+
+        if isinstance(play_frag, list):
+            for item in play_frag:
+                output = self._check_value(item)
+                if output:
+                    results += output
+
+        return results
+
+    def matchplay(self, file, play):
+        return self._check_value(play)

--- a/test/TestSudoRule.py
+++ b/test/TestSudoRule.py
@@ -1,0 +1,59 @@
+import unittest
+
+from ansiblelint.rules.SudoRule import SudoRule
+import ansiblelint.utils
+
+
+class TestSudoRule(unittest.TestCase):
+    simple_dict_yaml = {
+        'value1': '{foo}}',
+        'value2': 2,
+        'value3': ['foo', 'bar', '{baz}}'],
+        'value4': '{bar}',
+        'value5': '{{baz}',
+    }
+
+    def setUp(self):
+        self.rule = SudoRule()
+
+    def test_check_value_simple_matching(self):
+        result = self.rule._check_value("sudo: yes")
+        self.assertEquals(0, len(result))
+
+    def test_check_value_shallow_dict(self):
+        result = self.rule._check_value({ 'sudo': 'yes', 'sudo_user': 'somebody' })
+        self.assertEquals(2, len(result))
+
+    def test_check_value_nested(self):
+        yaml = [
+            {
+                'hosts': 'all',
+                'sudo': 'yes',
+                'sudo_user': 'nobody',
+                'tasks': [
+                   {
+                      'name': 'test',
+                      'debug': 'msg=test',
+                      'sudo': 'yes',
+                      'sudo_user': 'somebody'
+                   }
+                ]
+            }
+        ]
+        result = self.rule._check_value(yaml)
+        self.assertEquals(2, len(result))
+
+
+class TestSudoRuleWithFile(unittest.TestCase):
+    file1 = 'test/sudo.yml'
+
+    def setUp(self):
+        self.rule = SudoRule()
+
+    def test_matchplay_sudo(self):
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file1).read())
+
+        self.assertTrue(yaml)
+        for play in yaml:
+            result = self.rule.matchplay(self.file1, play)
+            self.assertEquals(2, len(result))

--- a/test/sudo.yml
+++ b/test/sudo.yml
@@ -1,0 +1,15 @@
+- hosts: all
+  sudo: yes
+  sudo_user: somebody
+  tasks:
+  - name: clone content repository
+    git:
+      repo: '{{ archive_services_repo_url }}'
+      dest: '/home/www'
+      accept_hostkey: yes
+      version: master
+      update: no
+    sudo: yes
+    sudo_user: nobody
+    notify:
+    - restart apache2


### PR DESCRIPTION
sudo/sudo_user are deprecated commands as of ansible 1.9. Instead playbooks should be using become/become_user. This rule looks for uses of sudo and sudo_user.