### PR TITLE
Octal file permissions rule

### DIFF
--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from ansiblelint import AnsibleLintRule
+import re
+
+class OctalPermissionsRule(AnsibleLintRule):
+    id = 'ANSIBLE0008'
+    shortdesc = 'Octal file permissions must contain leading zero'
+    description = 'Numeric file permissions without leading zero can behave' + \
+            'in unexpected ways. See ' + \
+            'http://docs.ansible.com/ansible/file_module.html'
+    tags = ['formatting']
+    digits_regex = re.compile(r'[0-9]+')
+    valid_permissions_regex = re.compile(r'0[0-7]{3}')
+
+    def matchtask(self, file, task):
+        try:
+            mode_str = str(task['action']['mode'])
+            # If it is a numeric permission,
+            if re.match(self.digits_regex, mode_str):
+                # Return the inverse of if it's valid
+                return not re.match(self.valid_permissions_regex, mode_str)
+        # If the task didn't have a 'mode' argument, it can't be wrong
+        except KeyError:
+            return False

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -28,16 +28,12 @@ class OctalPermissionsRule(AnsibleLintRule):
             'in unexpected ways. See ' + \
             'http://docs.ansible.com/ansible/file_module.html'
     tags = ['formatting']
-    digits_regex = re.compile(r'[0-9]+')
-    valid_permissions_regex = re.compile(r'0[0-7]{3}')
 
-    def matchtask(self, file, task):
-        try:
-            mode_str = str(task['action']['mode'])
-            # If it is a numeric permission,
-            if re.match(self.digits_regex, mode_str):
-                # Return the inverse of if it's valid
-                return not re.match(self.valid_permissions_regex, mode_str)
-        # If the task didn't have a 'mode' argument, it can't be wrong
-        except KeyError:
-            return False
+    # At least an indent, "mode:", optional whitespace, any digits, EOL
+    mode_regex = re.compile(r'^\s+mode:\s*[0-9]+\s*$')
+    # Same as above, but with a leading zero before three digits
+    valid_mode_regex = re.compile(r'^\s+mode:\s*0[0-7]{3}\s*$')
+
+    def match(self, file,line):
+        if re.match(self.mode_regex, line):
+            return not re.match(self.valid_mode_regex, line)

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -21,12 +21,13 @@
 from ansiblelint import AnsibleLintRule
 import re
 
+
 class OctalPermissionsRule(AnsibleLintRule):
     id = 'ANSIBLE0008'
     shortdesc = 'Octal file permissions must contain leading zero'
     description = 'Numeric file permissions without leading zero can behave' + \
-            'in unexpected ways. See ' + \
-            'http://docs.ansible.com/ansible/file_module.html'
+        'in unexpected ways. See ' + \
+        'http://docs.ansible.com/ansible/file_module.html'
     tags = ['formatting']
 
     # At least an indent, "mode:", optional whitespace, any digits, EOL
@@ -34,6 +35,6 @@ class OctalPermissionsRule(AnsibleLintRule):
     # Same as above, but with a leading zero before three digits
     valid_mode_regex = re.compile(r'^\s+mode:\s*0[0-7]{3}\s*$')
 
-    def match(self, file,line):
+    def match(self, file, line):
         if re.match(self.mode_regex, line):
             return not re.match(self.valid_mode_regex, line)

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -1,0 +1,53 @@
+import unittest
+import ansiblelint.utils
+from itertools import permutations, combinations
+from ansiblelint import RulesCollection
+from ansiblelint.rules.OctalPermissionsRule import OctalPermissionsRule
+
+class TestOctalPermissionsRule(unittest.TestCase):
+    rule = OctalPermissionsRule()
+    one_to_seven = [ str(digit) for digit in range(8) ]
+    # Problematic modes are any permutation of three digits in 1-7
+    bad_permutations = set(permutations(combinations(one_to_seven, 3), 3))
+    # Join tuples to strings and flatten the list
+    bad_modes = [
+            "".join(tup) for lst in bad_permutations for tup in lst
+    ]
+    # Valid modes are just the bad ones with a leading zero
+    good_modes = [ "0" + mode for mode in bad_modes ]
+
+    # Ensure that the given regex matches all octal numbers appropriately
+    def test_regex_positives(self):
+        for good in self.good_modes:
+            self.assertRegexpMatches(good, self.rule.valid_permissions_regex)
+
+    def test_regex_negatives(self):
+        for bad in self.bad_modes:
+            self.assertNotRegexpMatches(bad, self.rule.valid_permissions_regex)
+
+    def test_positives(self):
+        # Construct valid task dictionaries for every possible mode
+        successes = [{ "action": { "mode" : mode } for mode in self.good_modes }]
+        # Loop through all of them and ensure the rule is working
+        for success in successes:
+            self.assertFalse(self.rule.matchtask("", success))
+
+    def test_failures(self):
+        failures = [{ "action": { "mode" : mode } for mode in self.bad_modes }]
+        for failure in failures:
+            self.assertTrue(self.rule.matchtask("", failure))
+
+class TestOctalPermissionsRuleWithFile(unittest.TestCase):
+    collection = RulesCollection()
+
+    def test_file_positive(self):
+        self.collection.register(OctalPermissionsRule())
+        success = 'test/octalpermissions-success.yml'
+        good_runner = ansiblelint.Runner(self.collection, [success], [], [], [])
+        self.assertEqual([], good_runner.run())
+
+    def test_files(self):
+        self.collection.register(OctalPermissionsRule())
+        failure = 'test/octalpermissions-failure.yml'
+        bad_runner = ansiblelint.Runner(self.collection, [failure], [], [], [])
+        self.assertEqual(3, len(bad_runner.run()))

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -4,16 +4,17 @@ from itertools import permutations, combinations
 from ansiblelint import RulesCollection
 from ansiblelint.rules.OctalPermissionsRule import OctalPermissionsRule
 
+
 class TestOctalPermissionsRule(unittest.TestCase):
     rule = OctalPermissionsRule()
-    one_to_seven = [ str(digit) for digit in range(8) ]
+    one_to_seven = [str(digit) for digit in range(8)]
     # All possible modes are any permutation of three digits in 1-7
     bad_permutations = set(permutations(combinations(one_to_seven, 3), 3))
     # Join tuples to strings and flatten the list
-    modes = [ "".join(tup) for lst in bad_permutations for tup in lst ]
-    bad_modes = [ "    mode: " + mode for mode in modes ]
+    modes = ["".join(tup) for lst in bad_permutations for tup in lst]
+    bad_modes = ["    mode: " + mode for mode in modes]
     # Valid modes are just the bad ones with a leading zero
-    good_modes = [ "    mode: 0" + mode for mode in modes ]
+    good_modes = ["    mode: 0" + mode for mode in modes]
 
     # Ensure that the given regex matches all octal numbers appropriately
     def test_regex_positives(self):
@@ -25,6 +26,7 @@ class TestOctalPermissionsRule(unittest.TestCase):
         for bad in self.bad_modes:
             self.assertRegexpMatches(bad, self.rule.mode_regex)
             self.assertNotRegexpMatches(bad, self.rule.valid_mode_regex)
+
 
 class TestOctalPermissionsRuleWithFile(unittest.TestCase):
     collection = RulesCollection()

--- a/test/octalpermissions-failure.yml
+++ b/test/octalpermissions-failure.yml
@@ -1,0 +1,19 @@
+---
+- hosts: hosts
+  vars:
+    varset: varset
+  tasks:
+    - name: octal permissions test fail (600)
+      file:
+        path: foo
+        mode: 600
+
+    - name: octal permissions test fail (000)
+      file:
+        path: foo
+        mode: 000
+
+    - name: octal permissions test fail (123)
+      file:
+        path: foo
+        mode: 123

--- a/test/octalpermissions-success.yml
+++ b/test/octalpermissions-success.yml
@@ -1,0 +1,19 @@
+---
+- hosts: hosts
+  vars:
+    varset: varset
+  tasks:
+    - name: octal permissions test success (0600)
+      file:
+        path: foo
+        mode: 0600
+
+    - name: octal permissions test success (0000)
+      file:
+        path: foo
+        mode: 0000
+
+    - name: octal permissions test success (0123)
+      file:
+        path: foo
+        mode: 0123


### PR DESCRIPTION
Includes unit tests that test literally every possible octal permission with and without leading zeros!

Manual testing:
```
$ ./bin/ansible-lint -r lib/ansiblelint/rules test/octalpermissions-failure.yml 
[ANSIBLE0008] Octal file permissions must contain leading zero
test/octalpermissions-failure.yml:9
        mode: 600

[ANSIBLE0008] Octal file permissions must contain leading zero
test/octalpermissions-failure.yml:14
        mode: 000

[ANSIBLE0008] Octal file permissions must contain leading zero
test/octalpermissions-failure.yml:19
        mode: 123
$ ./bin/ansible-lint -r lib/ansiblelint/rules test/octalpermissions-success.yml 
$ 
```

Fixes #94 