### PR TITLE
Add rpm_key as an alternative module to rpm

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -33,7 +33,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     _commands = ['command', 'shell']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',
                 'svn': 'subversion', 'service': 'service', 'mount': 'mount',
-                'rpm': 'yum', 'yum': 'yum', 'apt-get': 'apt-get',
+                'rpm': 'yum or rpm_key', 'yum': 'yum', 'apt-get': 'apt-get',
                 'unzip': 'unarchive', 'tar': 'unarchive'}
 
     def matchtask(self, file, task):


### PR DESCRIPTION
The documented way of adding a key is with rpm --import <key.asc>.
This is provided by the rpm_key ansible module and not with yum.