### PR TITLE
Fix crash tasks with unicode string name (like name: héhé).

### DIFF
--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,7 +1,7 @@
 class Formatter(object):
 
     def format(self, match):
-        formatstr = "[{0}] {1}\n{2}:{3}\n{4}\n"
+        formatstr = u"[{0}] {1}\n{2}:{3}\n{4}\n"
         return formatstr.format(match.rule.id,
                                 match.message,
                                 match.filename,
@@ -12,7 +12,7 @@ class Formatter(object):
 class QuietFormatter(object):
 
     def format(self, match):
-        formatstr = "[{0}] {1}:{2}"
+        formatstr = u"[{0}] {1}:{2}"
         return formatstr.format(match.rule.id, match.filename,
                                 match.linenumber)
 
@@ -20,7 +20,7 @@ class QuietFormatter(object):
 class ParseableFormatter(object):
 
     def format(self, match):
-        formatstr = "{0}:{1}: [{2}] {3}"
+        formatstr = u"{0}:{1}: [{2}] {3}"
         return formatstr.format(match.filename,
                                 match.linenumber,
                                 match.rule.id,


### PR DESCRIPTION
When ansible-lint return error on action containing unicode, it crash with the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/ansible-lint", line 116, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/bin/ansible-lint", line 106, in main
    print(formatter.format(match))
  File "/usr/local/lib/python2.7/dist-packages/ansiblelint/formatters/__init__.py", line 9, in format
    match.line)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 25: ordinal not in range(128)
```

This pull request fix this kind of issue.