### PR TITLE
Renaming module parameters into __ansible_module__

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -36,7 +36,7 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
                   'rmdir': 'state=absent', 'rm': 'state=absent'}
 
     def matchtask(self, file, task):
-        if task["action"]["module"] in self._commands:
+        if task["action"]["__ansible_module__"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._arguments:
                 message = "{0} used in place of argument {1} to file module"

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -37,7 +37,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
                 'unzip': 'unarchive', 'tar': 'unarchive'}
 
     def matchtask(self, file, task):
-        if task["action"]["module"] in self._commands:
+        if task["action"]["__ansible_module__"] in self._commands:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._modules:
                 message = "{0} used in place of {1} module"

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -29,5 +29,5 @@ class GitHasVersionRule(AnsibleLintRule):
     tags = ['repeatability']
 
     def matchtask(self, file, task):
-        return (task['action']['module'] == 'git' and
+        return (task['action']['__ansible_module__'] == 'git' and
                 task['action'].get('version', 'HEAD') == 'HEAD')

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -30,5 +30,5 @@ class MercurialHasRevisionRule(AnsibleLintRule):
     tags = ['repeatability']
 
     def matchtask(self, file, task):
-        return (task['action']['module'] == 'hg' and
+        return (task['action']['__ansible_module__'] == 'hg' and
                 task['action'].get('revision', 'default') == 'default')

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -219,7 +219,7 @@ def rolename(filepath):
 
 def _kv_to_dict(v):
     (command, args, kwargs) = tokenize(v)
-    return (dict(module=command, module_arguments=args, **kwargs))
+    return (dict(__ansible_module__=command, module_arguments=args, **kwargs))
 
 
 def normalize_task(task):
@@ -239,10 +239,10 @@ def normalize_task(task):
             if isinstance(v, basestring):
                 v = _kv_to_dict(k + ' ' + v)
             elif not v:
-                v = dict(module=k)
+                v = dict(__ansible_module__=k)
             else:
                 if isinstance(v, dict):
-                    v.update(dict(module=k))
+                    v.update(dict(__ansible_module__=k))
                 else:
                     if k == '__line__':
                         # Keep the line number stored
@@ -264,7 +264,7 @@ def task_to_str(task):
     action = task.get("action")
     args = " ".join(["k=v" for (k, v) in action.items() if k != "module_arguments"] +
                     action.get("module_arguments"))
-    return "{0} {1}".format(action["module"], args)
+    return "{0} {1}".format(action["__ansible_module__"], args)
 
 
 def extract_from_list(blocks, candidates):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -66,7 +66,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(utils.normalize_task(task1), utils.normalize_task(task2))
 
     def test_normalize_complex_command(self):
-        task1 = dict(name="hello", action={'module': 'ec2',
+        task1 = dict(name="hello", action={'__ansible_module__': 'ec2',
                                            'region': 'us-east1',
                                            'etc': 'whatever'})
         task2 = dict(name="hello", ec2={'region': 'us-east1',
@@ -79,7 +79,7 @@ class TestUtils(unittest.TestCase):
 
     def test_normalize_task_is_idempotent(self):
         tasks = list()
-        tasks.append(dict(name="hello", action={'module': 'ec2',
+        tasks.append(dict(name="hello", action={'__ansible_module__': 'ec2',
                                                 'region': 'us-east1',
                                                 'etc': 'whatever'}))
         tasks.append(dict(name="hello", ec2={'region': 'us-east1', 'etc': 'whatever'}))


### PR DESCRIPTION
Avoid collision with action taking module arguments.

Fix for https://github.com/willthames/ansible-lint/issues/106
