### PR TITLE
Allow octal permissions of length 4

### DIFF
--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -33,7 +33,7 @@ class OctalPermissionsRule(AnsibleLintRule):
     # At least an indent, "mode:", optional whitespace, any digits, EOL
     mode_regex = re.compile(r'^\s+mode:\s*[0-9]+\s*$')
     # Same as above, but with a leading zero before three digits
-    valid_mode_regex = re.compile(r'^\s+mode:\s*0[0-7]{3}\s*$')
+    valid_mode_regex = re.compile(r'^\s+mode:\s*0[0-7]{3,4}\s*$')
 
     def match(self, file, line):
         if re.match(self.mode_regex, line):

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -1,31 +1,8 @@
 import unittest
 import ansiblelint.utils
-from itertools import permutations, combinations
+from itertools import product  # Cartesian product: all subsets of length n
 from ansiblelint import RulesCollection
 from ansiblelint.rules.OctalPermissionsRule import OctalPermissionsRule
-
-
-class TestOctalPermissionsRule(unittest.TestCase):
-    rule = OctalPermissionsRule()
-    one_to_seven = [str(digit) for digit in range(8)]
-    # All possible modes are any permutation of three digits in 1-7
-    bad_permutations = set(permutations(combinations(one_to_seven, 3), 3))
-    # Join tuples to strings and flatten the list
-    modes = ["".join(tup) for lst in bad_permutations for tup in lst]
-    bad_modes = ["    mode: " + mode for mode in modes]
-    # Valid modes are just the bad ones with a leading zero
-    good_modes = ["    mode: 0" + mode for mode in modes]
-
-    # Ensure that the given regex matches all octal numbers appropriately
-    def test_regex_positives(self):
-        for good in self.good_modes:
-            self.assertRegexpMatches(good, self.rule.mode_regex)
-            self.assertRegexpMatches(good, self.rule.valid_mode_regex)
-
-    def test_regex_negatives(self):
-        for bad in self.bad_modes:
-            self.assertRegexpMatches(bad, self.rule.mode_regex)
-            self.assertNotRegexpMatches(bad, self.rule.valid_mode_regex)
 
 
 class TestOctalPermissionsRuleWithFile(unittest.TestCase):
@@ -37,10 +14,9 @@ class TestOctalPermissionsRuleWithFile(unittest.TestCase):
         good_runner = ansiblelint.Runner(self.collection, [success], [], [], [])
         self.assertEqual([], good_runner.run())
 
-    def test_files(self):
+    def test_file_negative(self):
         self.collection.register(OctalPermissionsRule())
         failure = 'test/octalpermissions-failure.yml'
         bad_runner = ansiblelint.Runner(self.collection, [failure], [], [], [])
         errs = bad_runner.run()
-        # TODO: all errors are counted twice. Why?
-        self.assertEqual(6, len(errs))
+        self.assertEqual(5, len(errs))

--- a/test/octalpermissions-failure.yml
+++ b/test/octalpermissions-failure.yml
@@ -17,3 +17,13 @@
       file:
         path: foo
         mode: 123
+
+    - name: octal permissions test fail (4000)
+      file:
+        path: baz
+        mode: 4000
+
+    - name: octal permissions test fail (2000)
+      file:
+        path: bar
+        mode: 2000

--- a/test/octalpermissions-success.yml
+++ b/test/octalpermissions-success.yml
@@ -17,3 +17,13 @@
       file:
         path: foo
         mode: 0123
+
+    - name: octal permissions test success (04000)
+      file:
+        path: baz
+        mode: 04000
+
+    - name: octal permissions test success (02000)
+      file:
+        path: bar
+        mode: 02000


### PR DESCRIPTION
Fixes #109
Improves test coverage and efficiency considerably