### PR TITLE
Unique ID for OctalPermissionsRule

### DIFF
--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -23,7 +23,7 @@ import re
 
 
 class OctalPermissionsRule(AnsibleLintRule):
-    id = 'ANSIBLE0008'
+    id = 'ANSIBLE0009'
     shortdesc = 'Octal file permissions must contain leading zero'
     description = 'Numeric file permissions without leading zero can behave' + \
         'in unexpected ways. See ' + \


### PR DESCRIPTION
According to the project rules the ID should be a unique identifier. SudoRule already uses `ANSIBLE0008` as its id so I updated the ID of OctalPermissionsRule which was added later on.