### PR TITLE
altering regular expression to also include 'module: ... mode=octal'

### DIFF
--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -30,11 +30,15 @@ class OctalPermissionsRule(AnsibleLintRule):
         'http://docs.ansible.com/ansible/file_module.html'
     tags = ['formatting']
 
-    # At least an indent, "mode:", optional whitespace, any digits, EOL
-    mode_regex = re.compile(r'^\s+mode:\s*[0-9]+\s*$')
-    # Same as above, but with a leading zero before three digits
-    valid_mode_regex = re.compile(r'^\s+mode:\s*0[0-7]{3,4}\s*$')
+    _modules = {'assemble', 'copy', 'file', 'ini_file', 'lineinfile',
+                'replace', 'synchronize', 'template', 'unarchive'}
 
-    def match(self, file, line):
-        if re.match(self.mode_regex, line):
-            return not re.match(self.valid_mode_regex, line)
+    # At least an indent, "mode:", optional whitespace, any digits, EOL
+    mode_regex = re.compile(r'^\s*[0-9]+\s*$')
+    # Same as above, but with a leading zero before three digits
+    valid_mode_regex = re.compile(r'^\s*0[0-7]{3,4}\s*$')
+
+    def matchtask(self, file, task):
+        if task["action"]["module"] in self._modules:
+            if self.mode_regex.match(task['action']['module_arguments']['mode'][0]):
+                return not self.mode_regex.match(task['action']['module_arguments']['mode'][0])

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -19,4 +19,4 @@ class TestOctalPermissionsRuleWithFile(unittest.TestCase):
         failure = 'test/octalpermissions-failure.yml'
         bad_runner = ansiblelint.Runner(self.collection, [failure], [], [], [])
         errs = bad_runner.run()
-        self.assertEqual(5, len(errs))
+        self.assertEqual(6, len(errs))

--- a/test/octalpermissions-failure.yml
+++ b/test/octalpermissions-failure.yml
@@ -27,3 +27,6 @@
       file:
         path: bar
         mode: 2000
+
+    - name: octal permissions test fail (777)
+      file: path=baz mode=777

--- a/test/octalpermissions-success.yml
+++ b/test/octalpermissions-success.yml
@@ -27,3 +27,6 @@
       file:
         path: bar
         mode: 02000
+
+    - name: octal permissions test success (0777)
+      file: path=baz mode=0777


### PR DESCRIPTION
I am taking another stab at getting the octal permissions rule to function for all relevant situations.  This time I am also rewriting some of the original code to remove false positives as requested.
