### PR TITLE
Fix unicode error message problem

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -24,6 +24,7 @@ import os
 import sys
 
 import ansiblelint.utils
+import codecs
 
 
 class AnsibleLintRule(object):
@@ -68,7 +69,7 @@ class AnsibleLintRule(object):
                     result = self.matchtask(file, task)
                     if result:
                         message = None
-                        if isinstance(result, str):
+                        if isinstance(result, basestring):
                             message = result
                         taskstr = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
                         matches.append(Match(task[ansiblelint.utils.LINE_NUMBER_KEY], taskstr,
@@ -116,7 +117,7 @@ class RulesCollection(object):
         matches = list()
 
         try:
-            with open(playbookfile['path'], 'Ur') as f:
+            with codecs.open(playbookfile['path'], mode='rb', encoding='utf-8') as f:
                 text = f.read()
         except IOError, e:
             print("WARNING: Couldn't open %s - %s" %
@@ -166,7 +167,7 @@ class Match(object):
         self.message = message or rule.shortdesc
 
     def __repr__(self):
-        formatstr = "[{0}] ({1}) matched {2}:{3} {4}"
+        formatstr = u"[{0}] ({1}) matched {2}:{3} {4}"
         return formatstr.format(self.rule.id, self.message,
                                 self.filename, self.linenumber, self.line)
 

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -23,6 +23,7 @@ import unittest
 
 import ansiblelint
 from ansiblelint import RulesCollection
+from ansiblelint.formatters import Formatter
 
 
 class TestRule(unittest.TestCase):
@@ -39,13 +40,20 @@ class TestRule(unittest.TestCase):
     def test_unicode_runner_count(self):
         filename = 'test/unicode.yml'
         runner = ansiblelint.Runner(self.rules, {filename}, [], [], [])
-        assert (len(runner.run()) == 0)
+        assert (len(runner.run()) == 1)
+
+    def test_unicode_formatting(self):
+        filename = 'test/unicode.yml'
+        runner = ansiblelint.Runner(self.rules, {filename}, [], [], [])
+        matches = runner.run()
+        formatter = Formatter()
+        formatter.format(matches[0])
 
     def test_runner_excludes_paths(self):
         files = {'test/unicode.yml', 'examples/lots_of_warnings.yml'}
         excludes = ['examples/lots_of_warnings.yml']
         runner = ansiblelint.Runner(self.rules, files, [], [], excludes)
-        assert (len(runner.run()) == 0)
+        assert (len(runner.run()) == 1)
 
     def test_runner_block_count(self):
         files = {'test/block.yml'}

--- a/test/unicode.yml
+++ b/test/unicode.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: localhost
   connection: local
+  vars:
+    unicode_var: a_b_cö   
 
   tasks:
   - name: bonjour, ça va?


### PR DESCRIPTION
Ensure that playbooks are read as unicode, so that
when errors are output that rely on the content of
the playbook, they are in unicode too.

Fixes #140