### PR TITLE
initial commit

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -40,7 +40,7 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
                   'rmdir': 'state=absent', 'rm': 'state=absent'}
 
     def matchtask(self, file, task):
-        if task["action"]["module"] in self._commands:
+        if task["action"]["module"] in self._commands and task["action"]["module_arguments"]:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._arguments and \
                     boolean(task['action'].get('warn', True)) and \

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -41,7 +41,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
                 'unzip': 'unarchive', 'tar': 'unarchive'}
 
     def matchtask(self, file, task):
-        if task["action"]["module"] in self._commands:
+        if task["action"]["module"] in self._commands and task["action"]["module_arguments"]:
             executable = os.path.basename(task["action"]["module_arguments"][0])
             if executable in self._modules and \
                     boolean(task['action'].get('warn', True)) and \


### PR DESCRIPTION
The pull request ensure CommandsInsteadOfArgumentsRule and CommandsInsteadOfModulesRule do not fail on Ansible 1.9.x where the parsing of shell like variable assignation is not processed correctly.

If you input a playbook like this:

```yaml
- host: all
  gather_facts: no
  tasks:
    - shell: PATH=$PATH:/tmp
```

the task object is constructed as follows:

```python
# for ansible 1.9
{
  'action': {
    'PATH': '$PATH:/tmp',
    'module_arguments': [],
    'module': 'shell'
  },
  '__line__': 4
}

# for ansible 2.0
{
  'delegate_to': None,
  'action': {
    '_uses_shell': True,
    'module_arguments': [
      u'PATH=$PATH:/tmp'
    ],
    'module': 'command'
  },
  'shell': 'PATH=$PATH:/tmp',
  '__line__': 4
}
```

Both rules assumed modules_arguments is not empty, but that's not always the case.
