### PR TITLE
Add exception handling to avoid crash when to_json filter is used

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -149,8 +149,11 @@ def find_children(playbook):
 
 def template(basedir, value, vars, fail_on_undefined=False, **kwargs):
     try:
-        value = ansible_template(os.path.abspath(basedir), value, vars, **kwargs)
-    except AnsibleError:
+        value = ansible_template(os.path.abspath(basedir), value, vars,
+                                 **dict(kwargs, fail_on_undefined=fail_on_undefined))
+        # Hack to skip the following exception when using to_json filter on a variable.
+        # I guess the filter doesn't like empty vars...
+    except (AnsibleError, ValueError):
         # templating failed, so just keep value as is.
         pass
     return value


### PR DESCRIPTION
Hello,

In my playbook I'm using some to_json filter and ansible-lint crash with this exception :

```
Traceback (most recent call last):
     File "/usr/bin/ansible-lint", line 125, in <module>
     sys.exit(main(sys.argv[1:]))
     File "/usr/bin/ansible-lint", line 112, in main
     matches = runner.run()
     File "/usr/lib/python2.7/site-packages/ansiblelint/__init__.py", line 218, in run
     for child in ansiblelint.utils.find_children(arg):
     File "/usr/lib/python2.7/site-packages/ansiblelint/utils.py", line 137, in find_children
     for child in play_children(basedir, item, playbook[1]):
     File "/usr/lib/python2.7/site-packages/ansiblelint/utils.py", line 181, in play_children
     fail_on_undefined=False)
     File "/usr/lib/python2.7/site-packages/ansiblelint/utils.py", line 155, in template
     value = ansible_template(os.path.abspath(basedir), value, vars, **dict(kwargs, fail_on_undefined=fail_on_undefined))
     File "/usr/lib/python2.7/site-packages/ansiblelint/utils.py", line 62, in ansible_template
     return templar.template(varname, **kwargs)
     File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 354, in template
     return [self.template(v, preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides) for v in variable]
     File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 361, in template
     d[k] = self.template(variable[k], preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides)
     File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 361, in template
     d[k] = self.template(variable[k], preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides)
     File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 332, in template
     result = self._do_template(variable, preserve_trailing_newlines=preserve_trailing_newlines, escape_backslashes=escape_backslashes, fail_on_undefined=fail_on_undefined, overrides=overrides)
     File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 497, in  do_template
     res = j2_concat(rf)
     File "<template>", line 9, in root
     File "/usr/lib/python2.7/site-packages/ansible/plugins/filter/core.py", line 87, in to_json
     return json.dumps(a, cls=AnsibleJSONEncoder, *args, **kw)
     File "/usr/lib/python2.7/json/__init__.py", line 251, in dumps
     sort_keys=sort_keys, **kw).encode(obj)
     File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
     chunks = self.iterencode(o, _one_shot=True)
     File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
     return _iterencode(o, 0)
ValueError: Circular reference detected
```

In this pull request I propose a workaround which handles the ValueError exception throw. It's not perfect, but I didn't see a parameter in ansible to avoid filter execution.

Best,

Erouan