### PR TITLE
Adding colored output formatter

### DIFF
--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -83,9 +83,6 @@ def main(args):
     if options.parseable:
         formatter = formatters.ParseableFormatter()
 
-    if options.colored:
-        formatter = formatters.ColoredFormatter()
-
     if len(args) == 0 and not (options.listrules or options.listtags):
         parser.print_help(file=sys.stderr)
         return 1
@@ -121,7 +118,7 @@ def main(args):
         matches.extend(runner.run())
 
     for match in matches:
-        print(formatter.format(match))
+        print(formatter.format(match, options.colored))
 
     if len(matches):
         return 2

--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -48,9 +48,6 @@ def main(args):
     parser.add_option('-p', dest='parseable',
                       default=False, action='store_true',
                       help="parseable output in the format of pep8")
-    parser.add_option('-c', dest='colored',
-                      default=False, action='store_true',
-                      help="colored output using ANSI escape sequences")
     parser.add_option('-r', action='append', dest='rulesdir',
                       default=[], type='str',
                       help="specify one or more rules directories using "
@@ -72,6 +69,10 @@ def main(args):
     parser.add_option('-x', dest='skip_list', default=[],
                       help="only check rules whose id/tags do not " +
                       "match these values")
+    parser.add_option('--nocolor', dest='colored',
+                      default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
+                      action='store_false',
+                      help="disable colored output")
     parser.add_option('--exclude', dest='exclude_paths', action='append',
                       help='path to directories or files to skip. This option'
                            ' is repeatable.')

--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -48,6 +48,9 @@ def main(args):
     parser.add_option('-p', dest='parseable',
                       default=False, action='store_true',
                       help="parseable output in the format of pep8")
+    parser.add_option('-c', dest='colored',
+                      default=False, action='store_true',
+                      help="colored output using ANSI escape sequences")
     parser.add_option('-r', action='append', dest='rulesdir',
                       default=[], type='str',
                       help="specify one or more rules directories using "
@@ -79,6 +82,9 @@ def main(args):
 
     if options.parseable:
         formatter = formatters.ParseableFormatter()
+
+    if options.colored:
+        formatter = formatters.ColoredFormatter()
 
     if len(args) == 0 and not (options.listrules or options.listtags):
         parser.print_help(file=sys.stderr)

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,42 +1,52 @@
+try:
+    from ansiblelint.utils import stringc
+except ImportError:
+    from ansible.utils.color import stringc
+
+
 class Formatter(object):
 
-    def format(self, match):
-        formatstr = u"[{0}] {1}\n{2}:{3}\n{4}\n"
-        return formatstr.format(match.rule.id,
-                                match.message,
-                                match.filename,
-                                match.linenumber,
-                                match.line)
+    def format(self, match, colored):
+        formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
+
+        if colored:
+            return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
+                                    stringc(match.message, 'red'),
+                                    stringc(match.filename, 'blue'),
+                                    stringc(match.linenumber, 'cyan'),
+                                    stringc(match.line, 'magenta'))
+        else:
+            return formatstr.format(match.rule.id,
+                                    match.message,
+                                    match.filename,
+                                    match.linenumber,
+                                    match.line)
 
 
 class QuietFormatter(object):
 
-    def format(self, match):
-        formatstr = u"[{0}] {1}:{2}"
-        return formatstr.format(match.rule.id, match.filename,
-                                match.linenumber)
+    def format(self, match, colored):
+        formatstr = u"{0} {1}:{2}"
+        if colored:
+            return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
+                                    stringc(match.filename, 'blue'),
+                                    stringc(match.linenumber, 'cyan'))
+        else:
+            return formatstr.format(match.rule.id, match.filename,
+                                    match.linenumber)
 
 
 class ParseableFormatter(object):
 
-    def format(self, match):
+    def format(self, match, colored):
         formatstr = u"{0}:{1}: [{2}] {3}"
-        return formatstr.format(match.filename,
-                                match.linenumber,
-                                "E" + match.rule.id,
-                                match.message,
-                                )
-
-
-from ansiblelint.utils import stringc
-
-class ColoredFormatter(object):
-
-    def format(self, match):
-        formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
-        return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
-                                stringc(match.message, 'red'),
-                                stringc(match.filename, 'blue'),
-                                stringc(match.linenumber, 'cyan'),
-                                stringc(match.line, 'magenta')
-                                )
+        if colored:
+            return formatstr.format(stringc(match.filename, 'blue'),
+                                    stringc(match.linenumber, 'cyan'),
+                                    stringc(u"E{0}".format(match.rule.id), 'bright red'),
+                                    stringc(match.message, 'red'))
+        else:
+            return formatstr.format(match.filename,
+                                    match.linenumber,
+                                    "E" + match.rule.id,
+                                    match.message)

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -28,20 +28,15 @@ class ParseableFormatter(object):
                                 )
 
 
-try:
-    from ansible.color import stringc
-    ANSIBLE_VERSION = 1
-except ImportError:
-    from ansible.utils.color import stringc
-    ANSIBLE_VERSION = 2
+from ansiblelint.utils import stringc
 
 class ColoredFormatter(object):
 
     def format(self, match):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
         return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
-                                stringc(match.message,'red'),
-                                stringc(match.filename,'blue'),
+                                stringc(match.message, 'red'),
+                                stringc(match.filename, 'blue'),
                                 stringc(match.linenumber, 'cyan'),
                                 stringc(match.line, 'magenta')
                                 )

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,12 +1,12 @@
 try:
-    from ansiblelint.utils import stringc
+    from ansible.color import stringc
 except ImportError:
     from ansible.utils.color import stringc
 
 
 class Formatter(object):
 
-    def format(self, match, colored):
+    def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
 
         if colored:
@@ -25,7 +25,7 @@ class Formatter(object):
 
 class QuietFormatter(object):
 
-    def format(self, match, colored):
+    def format(self, match, colored=False):
         formatstr = u"{0} {1}:{2}"
         if colored:
             return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
@@ -38,7 +38,7 @@ class QuietFormatter(object):
 
 class ParseableFormatter(object):
 
-    def format(self, match, colored):
+    def format(self, match, colored=False):
         formatstr = u"{0}:{1}: [{2}] {3}"
         if colored:
             return formatstr.format(stringc(match.filename, 'blue'),

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -26,3 +26,16 @@ class ParseableFormatter(object):
                                 "E" + match.rule.id,
                                 match.message,
                                 )
+
+from ansiblelint.utils import stringc
+
+class ColoredFormatter(object):
+
+    def format(self, match):
+        formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
+        return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
+                                stringc(match.message,'red'),
+                                stringc(match.filename,'blue'),
+                                stringc(match.linenumber, 'cyan'),
+                                stringc(match.line, 'magenta')
+                                )

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -8,7 +8,6 @@ class Formatter(object):
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
-
         if colored:
             return formatstr.format(stringc(u"[{0}]".format(match.rule.id), 'bright red'),
                                     stringc(match.message, 'red'),

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -27,7 +27,13 @@ class ParseableFormatter(object):
                                 match.message,
                                 )
 
-from ansiblelint.utils import stringc
+
+try:
+    from ansible.color import stringc
+    ANSIBLE_VERSION = 1
+except ImportError:
+    from ansible.utils.color import stringc
+    ANSIBLE_VERSION = 2
 
 class ColoredFormatter(object):
 

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -30,7 +30,6 @@ from yaml.composer import Composer
 from yaml.constructor import Constructor
 
 try:
-    from ansible.color import stringc
     from ansible.utils import parse_yaml_from_file
     from ansible.utils import path_dwim
     from ansible.utils.template import template as ansible_template
@@ -38,7 +37,6 @@ try:
     module_loader = module_finder
     ANSIBLE_VERSION = 1
 except ImportError:
-    from ansible.utils.color import stringc
     from ansible.parsing.dataloader import DataLoader
     from ansible.template import Templar
     from ansible.parsing.mod_args import ModuleArgsParser

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -461,3 +461,34 @@ def parse_yaml_linenumbers(data, filename):
     except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
         raise SystemExit("Failed to parse YAML in %s: %s" % (filename, str(e)))
     return data
+
+
+# --- begin "pretty"
+#
+# pretty - A miniature library that provides a Python print and stdout
+# wrapper that makes colored terminal text easier to use (e.g. without
+# having to mess around with ANSI escape sequences). This code is public
+# domain - there is no license except that you must leave this header.
+#
+# Copyright (C) 2008 Brian Nez <thedude at bri1 dot com>
+#
+# http://nezzen.net/2008/06/23/colored-text-in-python-using-ansi-escape-sequences/
+
+codeCodes = {
+    'black':     u'0;30', 'bright gray':    u'0;37',
+    'blue':      u'0;34', 'white':          u'1;37',
+    'green':     u'0;32', 'bright blue':    u'1;34',
+    'cyan':      u'0;36', 'bright green':   u'1;32',
+    'red':       u'0;31', 'bright cyan':    u'1;36',
+    'purple':    u'0;35', 'bright red':     u'1;31',
+    'yellow':    u'0;33', 'bright purple':  u'1;35',
+    'dark gray': u'1;30', 'bright yellow':  u'1;33',
+    'magenta':   u'0;35', 'bright magenta': u'1;35',
+    'normal':    u'0'
+}
+
+def stringc(text, color):
+    """String in color."""
+    return u"\033[%sm%s\033[0m" % (codeCodes[color], text)
+
+# --- end "pretty"

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -462,33 +462,3 @@ def parse_yaml_linenumbers(data, filename):
         raise SystemExit("Failed to parse YAML in %s: %s" % (filename, str(e)))
     return data
 
-
-# --- begin "pretty"
-#
-# pretty - A miniature library that provides a Python print and stdout
-# wrapper that makes colored terminal text easier to use (e.g. without
-# having to mess around with ANSI escape sequences). This code is public
-# domain - there is no license except that you must leave this header.
-#
-# Copyright (C) 2008 Brian Nez <thedude at bri1 dot com>
-#
-# http://nezzen.net/2008/06/23/colored-text-in-python-using-ansi-escape-sequences/
-
-codeCodes = {
-    'black':     u'0;30', 'bright gray':    u'0;37',
-    'blue':      u'0;34', 'white':          u'1;37',
-    'green':     u'0;32', 'bright blue':    u'1;34',
-    'cyan':      u'0;36', 'bright green':   u'1;32',
-    'red':       u'0;31', 'bright cyan':    u'1;36',
-    'purple':    u'0;35', 'bright red':     u'1;31',
-    'yellow':    u'0;33', 'bright purple':  u'1;35',
-    'dark gray': u'1;30', 'bright yellow':  u'1;33',
-    'magenta':   u'0;35', 'bright magenta': u'1;35',
-    'normal':    u'0'
-}
-
-def stringc(text, color):
-    """String in color."""
-    return u"\033[%sm%s\033[0m" % (codeCodes[color], text)
-
-# --- end "pretty"

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -461,4 +461,3 @@ def parse_yaml_linenumbers(data, filename):
     except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
         raise SystemExit("Failed to parse YAML in %s: %s" % (filename, str(e)))
     return data
-

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -30,6 +30,7 @@ from yaml.composer import Composer
 from yaml.constructor import Constructor
 
 try:
+    from ansible.color import stringc
     from ansible.utils import parse_yaml_from_file
     from ansible.utils import path_dwim
     from ansible.utils.template import template as ansible_template
@@ -37,6 +38,7 @@ try:
     module_loader = module_finder
     ANSIBLE_VERSION = 1
 except ImportError:
+    from ansible.utils.color import stringc
     from ansible.parsing.dataloader import DataLoader
     from ansible.template import Templar
     from ansible.parsing.mod_args import ModuleArgsParser


### PR DESCRIPTION
Hi @willthames,

First of all thank you for ansible-lint!

I have worked on adding a colored output (really similar to the one used in the ansible project).

The default remains uncolored by adding ```-c``` will print colored rules.

Feel free to comment this PR, I will make the changes if needed!