### PR TITLE
Adding UsingBareVariablesIsDeprecated rule and tests

### DIFF
--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import re
+from ansiblelint import AnsibleLintRule
+
+
+class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
+    id = 'ANSIBLE1000'
+    shortdesc = 'Using bare variables is deprecated'
+    description = 'Using bare variables is deprecated. Update your' + \
+        'playbooks so that the environment value uses the full variable' + \
+        'syntax ("{{your_variable}}").'
+    tags = ['formatting']
+
+    _loops = re.compile(r'^with_.*$')
+    _jinja = re.compile("\{\{[^\}]*\}\}")
+
+    def matchtask(self, file, task):
+        loop_type = next((key for key in task.keys() if self._loops.match(key)), None)
+
+        if loop_type and isinstance(task[loop_type], basestring):
+                if not self._jinja.match(task[loop_type]):
+                    message = "Found a bare variable '{0}' used in a '{1}' loop." + \
+                        " You should use the full variable syntax ('{{{{{0}}}}}')"
+                    return message.format(task[loop_type], loop_type)

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -23,7 +23,7 @@ from ansiblelint import AnsibleLintRule
 
 
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
-    id = 'ANSIBLE1000'
+    id = 'ANSIBLE0014'
     shortdesc = 'Using bare variables is deprecated'
     description = 'Using bare variables is deprecated. Update your' + \
         'playbooks so that the environment value uses the full variable' + \

--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -1,0 +1,21 @@
+import unittest
+import ansiblelint.utils
+from ansiblelint import RulesCollection
+from ansiblelint.rules.UsingBareVariablesIsDeprecatedRule import UsingBareVariablesIsDeprecatedRule
+
+
+class TestUsingBareVariablesIsDeprecated(unittest.TestCase):
+    collection = RulesCollection()
+
+    def test_file_positive(self):
+        self.collection.register(UsingBareVariablesIsDeprecatedRule())
+        success = 'test/using-bare-variables-success.yml'
+        good_runner = ansiblelint.Runner(self.collection, success, [], [], [])
+        self.assertEqual([], good_runner.run())
+
+    def test_file_negative(self):
+        self.collection.register(UsingBareVariablesIsDeprecatedRule())
+        failure = 'test/using-bare-variables-failure.yml'
+        bad_runner = ansiblelint.Runner(self.collection, failure, [], [], [])
+        errs = bad_runner.run()
+        self.assertEqual(2, len(errs))

--- a/test/bar.txt
+++ b/test/bar.txt
@@ -1,0 +1,1 @@
+Bar file

--- a/test/foo.txt
+++ b/test/foo.txt
@@ -1,0 +1,1 @@
+Foo file

--- a/test/using-bare-variables-failure.yml
+++ b/test/using-bare-variables-failure.yml
@@ -1,0 +1,21 @@
+---
+- hosts: localhost
+  become: no
+  vars:
+    my_list:
+      - foo
+      - bar
+
+    my_dict:
+      foo: bar
+
+  tasks:
+    - name: with_items loop using bare variable
+      debug:
+        msg: "{{ item }}"
+      with_items: my_list
+
+    - name: with_dict loop using bare variable
+      debug:
+        msg: "{{ item }}"
+      with_dict: my_dict

--- a/test/using-bare-variables-success.yml
+++ b/test/using-bare-variables-success.yml
@@ -1,0 +1,79 @@
+---
+- hosts: localhost
+  become: no
+  vars:
+    my_list:
+      - foo
+      - bar
+
+    my_list2:
+      - 1
+      - 2
+
+    my_dict:
+      foo: bar
+
+  tasks:
+    ### Testing with_items loops
+    - name: with_items loop using static list
+      debug:
+        msg: "{{ item }}"
+      with_items:
+        - foo
+        - bar
+
+    - name: with_items using a static hash
+      debug:
+        msg: "{{ item.key }} - {{ item.value }}"
+      with_items:
+        - { key: foo, value: 1 }
+        - { key: bar, value: 2 }
+
+    - name: with_items loop using variable
+      debug:
+        msg: "{{ item }}"
+      with_items: "{{ my_list }}"
+
+    ### Testing with_nested loops
+    - name: with_nested loop using static lists
+      debug:
+        msg: "{{ item[0] }} - {{ item[1] }}"
+      with_nested:
+        - [ 'foo', 'bar' ]
+        - [ '1', '2', '3' ]
+
+    - name: with_nested loop using variable list and static
+      debug:
+        msg: "{{ item[0] }} - {{ item[1] }}"
+      with_nested:
+        - "{{ my_list }}"
+        - [ '1', '2', '3' ]
+
+    ### Testing with_dict
+    - name: with_dict loop using variable
+      debug:
+        msg: "{{ item.key }} - {{ item.value }}"
+      with_dict: "{{ my_dict }}"
+
+    ### Testing with_file
+    - name: with_file loop using static files list
+      debug:
+        msg: "{{ item }}"
+      with_file:
+        - foo.txt
+        - bar.txt
+
+    ### Testing with_fileglob
+    - name: with_fileglob loop using *.txt
+      debug:
+        msg: "{{ item }}"
+      with_fileglob:
+        - '*.txt'
+
+    ### Testing with_together
+    - name: with_together loop using variable lists
+      debug:
+        msg: "{{ item.0 }} - {{ item.1 }}"
+      with_together:
+        - "{{ my_list }}"
+        - "{{ my_list2 }}"


### PR DESCRIPTION
Hi @willthames it's me again :) ,

I have been working on implementing a new rule for the Ansible WARNING we usually get when we use vars like this in loops:

```{yaml}
---
- hosts: localhost
  become: no
  vars:
    my_list:
      - foo
      - bar

  tasks:
    - name: with_items loop using bare variable
      debug:
        msg: "{{ item }}"
      with_items: my_list
```

Which gives the following output
```{shell}
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{my_list}}').
This 
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

I am hoping this new rule can detect this kind of warning.