### PR TITLE
additional package managers to PackageIsNotLatest and a test for that rule

### DIFF
--- a/lib/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/lib/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -28,6 +28,10 @@ class PackageIsNotLatestRule(AnsibleLintRule):
                   'with or without a version'
     tags = ['repeatability']
 
+    _package_managers = ['yum', 'apt', 'dnf', 'homebrew', 'pacman', 'openbsd_package', 'pkg5',
+                         'portage', 'pkgutil', 'slackpkg', 'swdepot', 'zypper', 'bundler', 'pip',
+                         'pear', 'npm', 'gem', 'easy_install', 'bower', 'package']
+
     def matchtask(self, file, task):
-        return (task['action']['__ansible_module__'] in ['yum', 'apt', 'package'] and
+        return (task['action']['__ansible_module__'] in self._package_managers and
                 task['action'].get('state') == 'latest')

--- a/test/TestPackageIsNotLatest.py
+++ b/test/TestPackageIsNotLatest.py
@@ -1,0 +1,21 @@
+import unittest
+import ansiblelint.utils
+from ansiblelint import RulesCollection
+from ansiblelint.rules.PackageIsNotLatestRule import PackageIsNotLatestRule
+
+
+class TestPackageIsNotLatestRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def test_package_not_latest_positive(self):
+        self.collection.register(PackageIsNotLatestRule())
+        success = 'test/package-check-success.yml'
+        good_runner = ansiblelint.Runner(self.collection, success, [], [], [])
+        self.assertEqual([], good_runner.run())
+
+    def test_package_not_latest_negative(self):
+        self.collection.register(PackageIsNotLatestRule())
+        failure = 'test/package-check-failure.yml'
+        bad_runner = ansiblelint.Runner(self.collection, failure, [], [], [])
+        errs = bad_runner.run()
+        self.assertEqual(3, len(errs))

--- a/test/package-check-failure.yml
+++ b/test/package-check-failure.yml
@@ -1,0 +1,13 @@
+- tasks:
+  - name: install ansible
+    yum: name=ansible state=latest
+
+  - name: install ansible-lint
+    pip: name=ansible-lint
+    args:
+      state: latest
+
+  - name: install some-package
+    package:
+      name: some-package
+      state: latest

--- a/test/package-check-success.yml
+++ b/test/package-check-success.yml
@@ -1,0 +1,14 @@
+- tasks:
+  - name: install ansible
+    yum: name=ansible-2.1.0.0 state=present
+
+  - name: install ansible-lint
+    pip: name=ansible-lint
+    args:
+      state: present
+      version: 3.1.2
+
+  - name: install some-package
+    package:
+      name: some-package
+      state: present


### PR DESCRIPTION
More OS and language package managers for the rule and a test for the rule.
[list of ansible package modules](http://docs.ansible.com/ansible/list_of_packaging_modules.html)

I don't think the new test was added to tox based on the TravisCI output. What do I need to do for that?