### PR TITLE
implement a check for duplicate keys

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -40,6 +40,7 @@ class AnsibleLintRule(object):
     match = None
     matchtask = None
     matchplay = None
+    duplicate_keys = 'ignore'
 
     def matchlines(self, file, text):
         matches = []
@@ -61,7 +62,8 @@ class AnsibleLintRule(object):
         matches = []
         if not self.matchtask:
             return matches
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'],
+                                                        self.duplicate_keys)
         if yaml:
             for task in ansiblelint.utils.get_normalized_tasks(yaml, file):
                 # An empty `tags` block causes `None` to be returned if
@@ -84,7 +86,8 @@ class AnsibleLintRule(object):
         matches = []
         if not self.matchplay:
             return matches
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'],
+                                                        self.duplicate_keys)
         if yaml and hasattr(self, 'matchplay'):
             for play in yaml:
                 result = self.matchplay(file, play)

--- a/lib/ansiblelint/rules/FailOnDuplicateKeysRule.py
+++ b/lib/ansiblelint/rules/FailOnDuplicateKeysRule.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2016 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from ansiblelint import AnsibleLintRule
+
+
+class FailOnDuplicateKeysRule(AnsibleLintRule):
+    id = 'ANSIBLE0016'
+    shortdesc = 'Duplicate keys may be a sign of YAML errors'
+    description = 'While duplicate keys may be used intentionally as a way ' \
+        'of overriding default values "inherited" via YAML anchors, they ' \
+        'also be a sign of syntax errors in a task list (or other YAML ' \
+        'list of dictionaries).'
+
+    tags = ['bug']
+    duplicate_keys = 'error'
+
+    def matchtask(self, file, task):
+        return []

--- a/test/TestFailOnDuplicateKeysRule.py
+++ b/test/TestFailOnDuplicateKeysRule.py
@@ -1,0 +1,16 @@
+import unittest
+import ansiblelint.utils
+from ansiblelint import RulesCollection
+from ansiblelint.rules.FailOnDuplicateKeysRule import FailOnDuplicateKeysRule
+from yaml.constructor import ConstructorError
+
+
+class TestFailOnDuplicateKeysRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def test_fail_on_duplicate_keys(self):
+        self.collection.register(FailOnDuplicateKeysRule())
+        success = 'test/fail-on-duplicate-keys.yml'
+        with self.assertRaises(ConstructorError):
+            good_runner = ansiblelint.Runner(self.collection, success, [], [], [])
+            self.assertEqual([], good_runner.run())

--- a/test/TestSudoRule.py
+++ b/test/TestSudoRule.py
@@ -51,7 +51,8 @@ class TestSudoRuleWithFile(unittest.TestCase):
         self.rule = SudoRule()
 
     def test_matchplay_sudo(self):
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file1).read(), self.file1)
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file1).read(),
+                                                        self.file1, 'ignore')
 
         self.assertTrue(yaml)
         for play in yaml:
@@ -59,7 +60,8 @@ class TestSudoRuleWithFile(unittest.TestCase):
             self.assertEquals(2, len(result))
 
     def test_matchtask_sudo(self):
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file1).read(), self.file1)
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(open(self.file1).read(),
+                                                        self.file1, 'ignore')
         results = []
         for task in ansiblelint.utils.get_normalized_tasks(yaml, dict(path=self.file1, type='playbook')):
             results.append(self.rule.matchtask(self.file1, task))

--- a/test/fail-on-duplicate-keys.yml
+++ b/test/fail-on-duplicate-keys.yml
@@ -1,0 +1,9 @@
+- hosts: localhost
+  tasks:
+    - debug:
+        msg: task 1
+
+  hosts: localhost
+  tasks:
+    - debug:
+        msg: task 2


### PR DESCRIPTION
this will cause parsing to fail when encountering something like:

```
- hosts: localhost
  tasks:
    - debug:
        msg: task 1

  hosts: localhost
  tasks:
    - debug:
        msg: task 2
```
