### PR TITLE
Fix handling of new-style deps.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 description-file = README.md
 
 [flake8]
-max-line-length = 100
+max-line-length = 140
 exclude = .git,.hg,.svn,test,setup.py,__pycache__


### PR DESCRIPTION
It isn't really documented anywhere, but new-style deps raise a
deprecation warning if you use "role", so it doesn't make sense to raise
a linting exception in this case.

See https://github.com/ansible/ansible/blob/5d865ec1efd529db7eb7d02aefbf60b453123d48/lib/ansible/playbook/role/requirement.py#L147.

I originally had a simpler solution for this but had to flatten it out
with `continue` statements simply to get tox to pass the linting tests.