### PR TITLE
Optimize extract_from_list() function

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -415,15 +415,14 @@ def task_to_str(task):
 
 def extract_from_list(blocks, candidates):
     results = list()
-    for block in blocks:
-        for candidate in candidates:
-            if candidate in block:
-                if isinstance(block[candidate], list):
-                    results.extend(add_action_type(block[candidate], candidate))
-                elif block[candidate] is not None:
-                    raise RuntimeError(
-                        "Key '%s' defined, but bad value: '%s'" %
-                        (candidate, str(block[candidate])))
+    for candidate in candidates:
+        if candidate in blocks:
+            if isinstance(blocks[candidate], list):
+                results.extend(add_action_type(blocks[candidate], candidate))
+            elif blocks[candidate] is not None:
+                raise RuntimeError(
+                    "Key '%s' defined, but bad value: '%s'" %
+                    (candidate, str(blocks[candidate])))
     return results
 
 


### PR DESCRIPTION
Currently, if you have defined a variable in default.yaml called
foo_tasks, this breaks ansible-list:

 Traceback (most recent call last):
   File ".tox/linters/bin/ansible-lint", line 135, in <module>
     sys.exit(main(sys.argv[1:]))
   File ".tox/linters/bin/ansible-lint", line 122, in main
     matches.extend(runner.run())
   File ".tox/linters/local/lib/python2.7/site-packages/ansiblelint/__init__.py", line 239, in run
     skip_list=set(self.skip_list)))
   File ".tox/linters/local/lib/python2.7/site-packages/ansiblelint/__init__.py", line 140, in run
     matches.extend(rule.matchtasks(playbookfile, text))
   File ".tox/linters/local/lib/python2.7/site-packages/ansiblelint/__init__.py", line 66, in matchtasks
     for task in ansiblelint.utils.get_normalized_tasks(yaml, file):
   File ".tox/linters/local/lib/python2.7/site-packages/ansiblelint/utils.py", line 455, in get_normalized_tasks
     tasks = get_action_tasks(yaml, file)
   File ".tox/linters/local/lib/python2.7/site-packages/ansiblelint/utils.py", line 443, in get_action_tasks
     tasks.extend(extract_from_list(yaml, ['tasks', 'handlers', 'pre_tasks', 'post_tasks']))
   File ".tox/linters/local/lib/python2.7/site-packages/ansiblelint/utils.py", line 421, in extract_from_list
     if isinstance(block[candidate], list):

because we are doing a string comparison rather then actually checking if the key exists in the dictionary.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>