### PR TITLE
Bugfix in UsingBareVariablesIsDeprecatedRule for variable with default empty dictionary

### DIFF
--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -18,4 +18,4 @@ class TestUsingBareVariablesIsDeprecated(unittest.TestCase):
         failure = 'test/using-bare-variables-failure.yml'
         bad_runner = ansiblelint.Runner(self.collection, failure, [], [], [])
         errs = bad_runner.run()
-        self.assertEqual(2, len(errs))
+        self.assertEqual(3, len(errs))

--- a/test/using-bare-variables-failure.yml
+++ b/test/using-bare-variables-failure.yml
@@ -19,3 +19,9 @@
       debug:
         msg: "{{ item }}"
       with_dict: my_dict
+
+    ### Testing with_dict with a default empty dictionary
+    - name: with_dict loop using variable and default
+      debug:
+        msg: "{{ item.key }} - {{ item.value }}"
+      with_dict: uwsgi_ini | default({})

--- a/test/using-bare-variables-success.yml
+++ b/test/using-bare-variables-success.yml
@@ -55,6 +55,12 @@
         msg: "{{ item.key }} - {{ item.value }}"
       with_dict: "{{ my_dict }}"
 
+    ### Testing with_dict with a default empty dictionary
+    - name: with_dict loop using variable and default
+      debug:
+        msg: "{{ item.key }} - {{ item.value }}"
+      with_dict: "{{ uwsgi_ini | default({}) }}"
+
     ### Testing with_file
     - name: with_file loop using static files list
       debug:


### PR DESCRIPTION
Fixes https://github.com/willthames/ansible-lint/issues/190

# What?

Changes `BareVariablesIsDeprecatedRule` to check for bare variables the [same way Ansible 2 does it](https://github.com/ansible/ansible/commit/8716bf8021800a18cb8d6cfea3f296ba4f834692), by checking for  `{%` or `{{`.

# Why?

`BareVariablesIsDeprecatedRule` raises an error when a task has `with_items` with a default empty dictionary:  
```yml
- name: configure
  ini_file:
    option: "{{ item.key }}"
    value: "{{ item.value }}"
  with_dict: "{{ ini_options | default({}) }}"
```


