### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Setup
 
 Using pip:
 ```
-pip install ansible-lint
+pip2.7 install ansible-lint
 ```
 
 From source:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Setup
 
 Using pip:
 ```
-pip2.7 install ansible-lint
+pip2 install ansible-lint
 ```
 
 From source:


### PR DESCRIPTION
We need to specify the version of pip to use because on new systems like Ubuntu 16.03, Python3 is the default and 'pip install' will install ansible-lint for Python 3, then a dumb user like myself will report random failures.