### PR TITLE
pre-commit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ As of version 2.4.0, ansible-lint now works just on roles (this is useful
 for CI of roles)
 
 
+Pre-commit
+==========
+
+To use ansible-lint with [pre-commit](http://pre-commit.com/), just 
+add the following to your local repo's `.pre-commit-config.yaml` file. 
+Make sure to change `sha:` to be either a git commit sha or tag of 
+ansible-lint containing `hooks.yaml`.
+
+```yaml
+- repo: https://github.com/willthames/ansible-lint.git
+  sha: v3.3.1
+  hooks:
+    - id: ansible-lint
+      files: \.(yaml|yml)$
+```
+
 
 Contributing
 ============

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,0 +1,11 @@
+---
+
+# For use with pre-commit.
+# See usage instructions at http://pre-commit.com
+
+-   id: ansible-lint
+    name: Ansible-lint
+    description: This hook runs ansible-lint.
+    entry: ansible-lint
+    language: python
+    files: \.(yaml|yml)$


### PR DESCRIPTION
# What?
Added a `hooks.yaml` file so `ansible-lint` can be easily used with [pre-commit](http://pre-commit.com)

# Why?
[Pre-commit](http://pre-commit.com) is a great tool used to more easily define git pre-commit hooks.  There are many [supported hooks](http://pre-commit.com/hooks.html), but ansible-lint is not currently one of them.  This PR will change that.

When this is merged, I will open a PR to add this to the [pre-commit supported hooks](http://pre-commit.com/hooks.html) page.