### PR TITLE
Treat NEWLINE as a shell special character

### DIFF
--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -39,4 +39,4 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
         # rather than pipes
         if task["action"]["__ansible_module__"] == 'shell':
             unjinjad_cmd = unjinja(' '.join(task["action"].get("__ansible_arguments__", [])))
-            return not any([ch in unjinjad_cmd for ch in ['&', '|', '<', '>', ';', '$']])
+            return not any([ch in unjinjad_cmd for ch in ['&', '|', '<', '>', ';', '$', '\n']])


### PR DESCRIPTION
It allows us to write a shell task having multiple commands
using literal style. Like this:

```
  - name: collecting and compressing static assets
    shell: |
      set -e
      cd /usr/share/openstack-dashboard
      python manage.py collectstatic --noinput
      python manage.py compress --force
```