### PR TITLE
Fix missing filename in exceptions

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -487,6 +487,7 @@ def parse_yaml_linenumbers(data, filename):
     def construct_mapping(node, deep=False):
         mapping = Constructor.construct_mapping(loader, node, deep=deep)
         mapping[LINE_NUMBER_KEY] = node.__line__
+        mapping[FILENAME_KEY] = filename
         return mapping
 
     try:


### PR DESCRIPTION
Without this, exceptions raised when parsing tasks uniformly report
"Unknown" as their filename and line number.