### PR TITLE
fix regression in TestUsingBareVariablesIsDeprecated

### DIFF
--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -18,4 +18,4 @@ class TestUsingBareVariablesIsDeprecated(unittest.TestCase):
         failure = 'test/using-bare-variables-failure.yml'
         bad_runner = ansiblelint.Runner(self.collection, failure, [], [], [])
         errs = bad_runner.run()
-        self.assertEqual(12, len(errs))
+        self.assertEqual(13, len(errs))

--- a/test/using-bare-variables-failure.yml
+++ b/test/using-bare-variables-failure.yml
@@ -16,6 +16,10 @@
       - foo: 3
         bar: 4
 
+    my_list_of_lists:
+      - "{{ my_list }}"
+      - "{{ my_list2 }}"
+
     my_filenames:
       - foo.txt
       - bar.txt
@@ -92,3 +96,8 @@
       with_flattened:
         - my_list
         - my_list2
+
+    - name: with_flattened loop with a variable
+      debug:
+        msg: "{{ item }}"
+      with_flattened: my_list_of_lists

--- a/test/using-bare-variables-success.yml
+++ b/test/using-bare-variables-success.yml
@@ -16,6 +16,10 @@
       - foo: 3
         bar: 4
 
+    my_list_of_lists:
+      - "{{ my_list }}"
+      - "{{ my_list2 }}"
+
     my_filenames:
       - foo.txt
       - bar.txt
@@ -144,6 +148,11 @@
       with_flattened:
         - "{{ my_list }}"
         - "{{ my_list2 }}"
+
+    - name: with_flattened loop with a variable
+      debug:
+        msg: "{{ item }}"
+      with_flattened: "{{ my_list_of_lists }}"
 
     - name: with_inventory_hostnames loop
       debug:


### PR DESCRIPTION
Fix regression introduced in https://github.com/willthames/ansible-lint/pull/201 that occurs when `with_together` is used with a single variable (instead of a list):

```yml
    - name: with_flattened loop with a variable
      debug:
        msg: "{{ item }}"
      with_flattened: "{{ some_list }}"
```

This was failing ansible-lint with:

```
ANSIBLE0015 Found a bare variable '{{ some_list }}' used in a 'with_flattened' loop. You should use the full variable syntax ('{{{{ some_list }}}}')
```