### PR TITLE
Use the code in ansible.parsing rather than module_utils

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -24,7 +24,7 @@ import os
 
 import ansible.constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils.splitter import split_args
+from ansible.parsing.splitter import split_args
 import yaml
 from yaml.composer import Composer
 from yaml.constructor import Constructor


### PR DESCRIPTION
The code in module_utils seems to not be python 3 compliant ( Bochecha on irc showed me traceback ) and is duplicated between the 2 modules. So I am trying to clean that upstream in ansible.