### PR TITLE
Only trigger modules-instead-of-commands for specific VCS subcommands

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -35,8 +35,9 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     tags = ['resources']
 
     _commands = ['command', 'shell']
-    _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',
-                'svn': 'subversion', 'service': 'service', 'mount': 'mount',
+    _modules = {'git clone': 'git', 'hg clone': 'hg', 'curl': 'get_url or uri',
+                'wget': 'get_url or uri', 'svn checkout': 'subversion',
+                'svn co': 'subversion', 'service': 'service', 'mount': 'mount',
                 'rpm': 'yum or rpm_key', 'yum': 'yum', 'apt-get': 'apt-get',
                 'unzip': 'unarchive', 'tar': 'unarchive', 'chkconfig': 'service',
                 'rsync': 'synchronize'}


### PR DESCRIPTION
git, hg, and svn do lots and lots of things, but their modules can
only do some of those things. Only trigger the
CommandsInsteadOfModules rule when those are being used to clone/check
out.

This does introduce some false negatives, e.g. where someone does 'git
--no-pager clone ...', but false negatives in this case are preferable
to false positives.
