### PR TITLE
Handle when: conditions that are not strings

### DIFF
--- a/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -29,6 +29,10 @@ class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
     tags = ['behaviour']
 
     def matchtask(self, file, task):
-        if 'when' in task:
-            return any([changed in task['when'] for changed in
-                        ['.changed', '|changed', '["changed"]', "['changed']"]])
+        try:
+            return any(changed in task.get('when') for changed in
+                       ['.changed', '|changed', '["changed"]', "['changed']"])
+        except TypeError:
+            # task['when'] was not iterable -- probably None (i.e.,
+            # it's not there) or boolean
+            pass

--- a/test/use-handler-rather-than-when-changed-success.yml
+++ b/test/use-handler-rather-than-when-changed-success.yml
@@ -12,3 +12,7 @@
     debug:
       msg: why isn't this a handler
     when: result.stdout == "hello"
+
+  - name: never actually debug
+    debug: var=result
+    when: False


### PR DESCRIPTION
It may be silly to specify a boolean as a when condition, but it's
legal, and we shouldn't raise an exception when it happens.