### PR TITLE
Add globbing, generator characters to shell check

### DIFF
--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -39,4 +39,4 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
         # rather than pipes
         if task["action"]["__ansible_module__"] == 'shell':
             unjinjad_cmd = unjinja(' '.join(task["action"].get("__ansible_arguments__", [])))
-            return not any([ch in unjinjad_cmd for ch in ['&', '|', '<', '>', ';', '$', '\n']])
+            return not any([ch in unjinjad_cmd for ch in '&|<>;$\n*[]{}?'])

--- a/test/command-instead-of-shell-success.yml
+++ b/test/command-instead-of-shell-success.yml
@@ -13,3 +13,15 @@
 
   - name: use variables
     shell: echo $HOME $USER
+
+  - name: use * for globbing
+    shell: ls foo*
+
+  - name: use ? for globbing
+    shell: ls foo?
+
+  - name: use [] for globbing
+    shell: ls foo[1,2,3]
+
+  - name: use shell generator
+    shell: ls foo{.txt,.xml}


### PR DESCRIPTION
The shell globbing (*?[]) and generator ({}) characters need to be
added to UseCommandInsteadOfShell so that we don't flag actions that
use those shell functions as needing to be converted to command.