### PR TITLE
fixup for #165 - unconditional commands in handlers

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -222,9 +222,14 @@ def _taskshandlers_children(basedir, k, v, parent_type):
     results = []
     for th in v:
         if 'include' in th:
+            # taskshandlers_children only get's called for playbooks, thus the
+            # actual type of the included tasks is the section containing the
+            # include, e.g. tasks, pre_tasks, or handlers.
+            assert(parent_type == 'playbook')
+            playbook_section = k
             results.append({
                 'path': path_dwim(basedir, th['include']),
-                'type': 'tasks'
+                'type': playbook_section
             })
         elif 'block' in th:
             results.extend(_taskshandlers_children(basedir, k, th['block'], parent_type))

--- a/test/command-check-success.yml
+++ b/test/command-check-success.yml
@@ -42,3 +42,4 @@
 - handlers:
   - name: restart something
     command: do something
+  - include: included-handlers.yml

--- a/test/included-handlers.yml
+++ b/test/included-handlers.yml
@@ -1,0 +1,6 @@
+---
+- name: restart xyz
+  service: name=xyz state=restarted
+# see Issue #165
+- name: command handler issue 165
+  command: do something


### PR DESCRIPTION
- get correct type of included tasks from playbook
  section containing the include

Also see #165 and d9a6aa08d347a8b48418f379ea5a42078608be08.