### PR TITLE
Sort matches by filename

### DIFF
--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -120,7 +120,7 @@ def main(args):
                                     options.verbosity)
         matches.extend(runner.run())
 
-    matches.sort(key=lambda x: (x.linenumber, x.rule.id))
+    matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
 
     for match in matches:
         print(formatter.format(match, options.colored))


### PR DESCRIPTION
In multi-file playbooks all matches are currently strictly sorted by filename - therefore different files are wildly mixed together. This is not to be expected at all and produces a quite confusing output. Sorting by code location should first order by filename and then by line number, eventually by rule number if there are multiple reportings per line.

Before:
```
$ ansible-lint -p playbooks.yml
error_b.yml:9: [EANSIBLE0012] Commands should not change things if nothing needs doing
error_a.yml:12: [EANSIBLE0012] Commands should not change things if nothing needs doing
error_b.yml:13: [EANSIBLE0012] Commands should not change things if nothing needs doing
```

After:
```
$ ansible-lint -p playbooks.yml
error_a.yml:12: [EANSIBLE0012] Commands should not change things if nothing needs doing
error_b.yml:9: [EANSIBLE0012] Commands should not change things if nothing needs doing
error_b.yml:13: [EANSIBLE0012] Commands should not change things if nothing needs doing
```

Followup to #219

A possible improvement would be to group the output by file, that would make it easier to recognize context.
Maybe there is a use case to make primary sorting value configurable, but sorting by file and line number should be the expected default.