### PR TITLE
Allow blocks in tasks/handlers to include

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -222,11 +222,13 @@ def _taskshandlers_children(basedir, k, v, parent_type):
     results = []
     for th in v:
         if 'include' in th:
-            # taskshandlers_children only get's called for playbooks, thus the
+            # when taskshandlers_children is called for playbooks, the
             # actual type of the included tasks is the section containing the
             # include, e.g. tasks, pre_tasks, or handlers.
-            assert(parent_type == 'playbook')
-            playbook_section = k
+            if parent_type == 'playbook':
+                playbook_section = k
+            else:
+                playbook_section = parent_type
             results.append({
                 'path': path_dwim(basedir, th['include']),
                 'type': playbook_section


### PR DESCRIPTION
Remove incorrect assertion, and handle the situation
when tasks or handlers files have blocks containing
an include.

Fixes #224