### PR TITLE
Add deprecated tag to ANSIBLE0015

### DIFF
--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -29,7 +29,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
     description = 'Using bare variables is deprecated. Update your' + \
         'playbooks so that the environment value uses the full variable' + \
         'syntax ("{{your_variable}}").'
-    tags = ['formatting']
+    tags = ['formatting', 'deprecated']
 
     _jinja = re.compile("\{\{.*\}\}")
     _glob = re.compile('[][*?]')


### PR DESCRIPTION
ANSIBLE0015 is currently tagged as ```formatting``` however it also reflects identification of a deprecated syntax.

I believe it should also be tagged as ```deprecated```, given that its error:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment 
value uses the full variable syntax ('{{people}}').
This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

is similar to the error for ANSIBLE0008 which is tagged as ```deprecated```.

```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 
'sudo' (default).
This feature will be removed in a future release. Deprecation warnings can be disabled 
by setting deprecation_warnings=False in ansible.cfg.
```