### PR TITLE
Add rule for always_run which is deprecated in ansible v2.2

### DIFF
--- a/examples/example.yml
+++ b/examples/example.yml
@@ -43,3 +43,7 @@
 
   - name: apt latest
     apt: state=latest name=apache2
+
+  - name: always run
+    debug: msg="always_run is deprecated"
+    always_run: true

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2017 Anth Courtney <anthcourtney@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from ansiblelint import AnsibleLintRule
+
+
+class AlwaysRunRule(AnsibleLintRule):
+    id = 'ANSIBLE0018'
+    shortdesc = 'Deprecated always_run'
+    description = 'Instead of always_run, use check_mode.'
+    tags = ['deprecated']
+
+    def matchtask(self, file, task):
+        return 'always_run' in task

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -76,8 +76,8 @@ VALID_KEYS = [
     'name', 'action', 'when', 'async', 'poll', 'notify',
     'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
     'delegate_to', 'local_action', 'transport', 'remote_user', 'sudo', 'sudo_user',
-    'sudo_pass', 'when', 'connection', 'environment', 'args',
-    'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
+    'sudo_pass', 'when', 'connection', 'environment', 'args', 'always_run',
+    'any_errors_fatal', 'changed_when', 'failed_when', 'check_mode', 'delay', 'retries', 'until',
     'su', 'su_user', 'su_pass', 'no_log', 'run_once',
     'become', 'become_user', 'become_method', FILENAME_KEY,
 ]

--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -1,0 +1,21 @@
+import unittest
+from ansiblelint import RulesCollection, Runner
+from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
+
+
+class TestAlwaysRun(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.register(AlwaysRunRule())
+
+    def test_file_positive(self):
+        success = 'test/always-run-success.yml'
+        good_runner = Runner(self.collection, success, [], [], [])
+        self.assertEqual([], good_runner.run())
+
+    def test_file_negative(self):
+        failure = 'test/always-run-failure.yml'
+        bad_runner = Runner(self.collection, failure, [], [], [])
+        errs = bad_runner.run()
+        self.assertEqual(1, len(errs))

--- a/test/always-run-failure.yml
+++ b/test/always-run-failure.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+
+  tasks:
+  - name: always_run is deprecated
+    debug: msg="always_run is deprecated"
+    always_run: yes

--- a/test/always-run-success.yml
+++ b/test/always-run-success.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+
+  tasks:
+  - name: always_run is deprecated
+    debug: msg="always_run is deprecated"
+    check_mode: yes


### PR DESCRIPTION
As per #220, ```always_run``` is deprecated in ansible v2.2 and has been replaced by ```check_mode```.