### PR TITLE
Move skip_ansible_lint check into get_normalized_tasks()

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -66,11 +66,6 @@ class AnsibleLintRule(object):
         yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
         if yaml:
             for task in ansiblelint.utils.get_normalized_tasks(yaml, file):
-                # An empty `tags` block causes `None` to be returned if
-                # the `or []` is not present - `task.get('tags', [])`
-                # does not suffice.
-                if 'skip_ansible_lint' in (task.get('tags') or []):
-                    continue
                 if 'action' in task:
                     result = self.matchtask(file, task)
                     if result:

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -485,7 +485,17 @@ def get_action_tasks(yaml, file):
 
 def get_normalized_tasks(yaml, file):
     tasks = get_action_tasks(yaml, file)
-    return [normalize_task(task, file['path']) for task in tasks]
+    res = []
+    for task in tasks:
+        # An empty `tags` block causes `None` to be returned if
+        # the `or []` is not present - `task.get('tags', [])`
+        # does not suffice.
+        if 'skip_ansible_lint' in (task.get('tags') or []):
+            # No need to normalize_task is we are skipping it.
+            continue
+        res.append(normalize_task(task, file['path']))
+
+    return res
 
 
 def parse_yaml_linenumbers(data, filename):

--- a/test/skiptasks.yml
+++ b/test/skiptasks.yml
@@ -16,6 +16,11 @@
     - name: test ANSIBLE0007
       command: creates=B chmod 644 A
 
+    - name: test invalid action (skip)
+      foo: bar
+      tags:
+        - skip_ansible_lint
+
     - name: test ANSIBLE0004 (skip)
       action: git
       tags:


### PR DESCRIPTION
It is possible we to skip invalid tasks, becase they are custom and
the local environment may not have the plugins installed properly. As
a result, move the skip check into get_normalized_tasks() and skip the
norimalize process if skip_ansible_lint exists.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>