### PR TITLE
make sure each file is only linted once

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -194,7 +194,7 @@ class Runner(object):
         self.skip_list = skip_list
         self._update_exclude_paths(exclude_paths)
         self.verbosity = verbosity
-        if checked_files == None:
+        if checked_files is None:
             checked_files = set()
         self.checked_files = checked_files
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -180,7 +180,7 @@ class Match(object):
 class Runner(object):
 
     def __init__(self, rules, playbook, tags, skip_list, exclude_paths,
-                 verbosity=0):
+                 verbosity=0, checked_files=None):
         self.rules = rules
         self.playbooks = set()
         # assume role if directory
@@ -194,6 +194,9 @@ class Runner(object):
         self.skip_list = skip_list
         self._update_exclude_paths(exclude_paths)
         self.verbosity = verbosity
+        if checked_files == None:
+            checked_files = set()
+        self.checked_files = checked_files
 
     def _update_exclude_paths(self, exclude_paths):
         if exclude_paths:
@@ -231,10 +234,14 @@ class Runner(object):
                 visited.add(arg)
 
         matches = list()
+        # remove files that have already been checked
+        files = [x for x in files if x['path'] not in self.checked_files]
         for file in files:
             if self.verbosity > 0:
                 print("Examining %s of type %s" % (file['path'], file['type']))
             matches.extend(self.rules.run(file, tags=set(self.tags),
                            skip_list=set(self.skip_list)))
+        # update list of checked files
+        self.checked_files.update([x['path'] for x in files])
 
         return matches

--- a/lib/ansiblelint/main/__init__.py
+++ b/lib/ansiblelint/main/__init__.py
@@ -114,10 +114,11 @@ def main():
 
     playbooks = set(args)
     matches = list()
+    checked_files = set()
     for playbook in playbooks:
         runner = ansiblelint.Runner(rules, playbook, options.tags,
                                     options.skip_list, options.exclude_paths,
-                                    options.verbosity)
+                                    options.verbosity, checked_files)
         matches.extend(runner.run())
 
     matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -100,3 +100,16 @@ class TestRule(unittest.TestCase):
         filename = os.path.abspath('test')
         runner = Runner(self.rules, filename, [], [], [])
         assert (list(runner.playbooks)[0][1] == 'role')
+
+    def test_files_not_scanned_twice(self):
+        checked_files = set()
+
+        filename = os.path.abspath('test/common-include-1.yml')
+        runner = Runner(self.rules, filename, [], [], [], 0, checked_files)
+        run1 = runner.run()
+
+        filename = os.path.abspath('test/common-include-2.yml')
+        runner = Runner(self.rules, filename, [], [], [], 0, checked_files)
+        run2 = runner.run()
+
+        assert ((len(run1) + len(run2)) == 1)

--- a/test/common-include-1.yml
+++ b/test/common-include-1.yml
@@ -1,0 +1,4 @@
+---
+- hosts: webservers
+  tasks:
+    - include: included-with-lint.yml

--- a/test/common-include-2.yml
+++ b/test/common-include-2.yml
@@ -1,0 +1,4 @@
+---
+- hosts: webservers
+  tasks:
+    - include: included-with-lint.yml

--- a/test/included-with-lint.yml
+++ b/test/included-with-lint.yml
@@ -1,0 +1,3 @@
+# missing a task name
+- yum:
+    name: ansible


### PR DESCRIPTION
this improves command-line performance by tracking which files have
already been linted