### PR TITLE
Handle the 'cmd' argument in command/shell

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -47,9 +47,14 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
                   'rmdir': 'state=absent', 'rm': 'state=absent'}
 
     def matchtask(self, file, task):
-        if task["action"]["__ansible_module__"] in self._commands and \
-                task["action"]["__ansible_arguments__"]:
-            executable = os.path.basename(task["action"]["__ansible_arguments__"][0])
+        if task["action"]["__ansible_module__"] in self._commands:
+            if 'cmd' in task['action']:
+                first_cmd_arg = task['action']['cmd'].split()[0]
+            else:
+                first_cmd_arg = task["action"]["__ansible_arguments__"][0]
+            if not first_cmd_arg:
+                return
+            executable = os.path.basename(first_cmd_arg)
             if executable in self._arguments and \
                     boolean(task['action'].get('warn', True)):
                 message = "{0} used in place of argument {1} to file module"

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -49,9 +49,14 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
                 'rsync': 'synchronize'}
 
     def matchtask(self, file, task):
-        if task["action"]["__ansible_module__"] in self._commands and \
-                task["action"]["__ansible_arguments__"]:
-            executable = os.path.basename(task["action"]["__ansible_arguments__"][0])
+        if task["action"]["__ansible_module__"] in self._commands:
+            if 'cmd' in task['action']:
+                first_cmd_arg = task['action']['cmd'].split()[0]
+            else:
+                first_cmd_arg = task["action"]["__ansible_arguments__"][0]
+            if not first_cmd_arg:
+                return
+            executable = os.path.basename(first_cmd_arg)
             if executable in self._modules and \
                     boolean(task['action'].get('warn', True)):
                 message = "{0} used in place of {1} module"

--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -30,10 +30,14 @@ class EnvVarsInCommandRule(AnsibleLintRule):
     tags = ['bug']
 
     expected_args = ['chdir', 'creates', 'executable', 'removes', 'warn',
-                     '__ansible_module__', '__ansible_arguments__',
+                     'cmd', '__ansible_module__', '__ansible_arguments__',
                      LINE_NUMBER_KEY, FILENAME_KEY]
 
     def matchtask(self, file, task):
         if task["action"]["__ansible_module__"] in ['shell', 'command']:
+            if 'cmd' in task['action']:
+                first_cmd_arg = task['action']['cmd'].split()[0]
+            else:
+                first_cmd_arg = task['action']['__ansible_arguments__'][0]
             return any([arg not in self.expected_args for arg in task['action']] +
-                       ["=" in task['action']['__ansible_arguments__'][0]])
+                       ["=" in first_cmd_arg])

--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -38,5 +38,8 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
         # Use unjinja so that we don't match on jinja filters
         # rather than pipes
         if task["action"]["__ansible_module__"] == 'shell':
-            unjinjad_cmd = unjinja(' '.join(task["action"].get("__ansible_arguments__", [])))
+            if 'cmd' in task['action']:
+                unjinjad_cmd = unjinja(task["action"].get("cmd", []))
+            else:
+                unjinjad_cmd = unjinja(' '.join(task["action"].get("__ansible_arguments__", [])))
             return not any([ch in unjinjad_cmd for ch in '&|<>;$\n*[]{}?'])

--- a/test/command-check-success.yml
+++ b/test/command-check-success.yml
@@ -19,6 +19,13 @@
   - name: command with inline removes
     command: removes=Z echo blah
 
+  - name: command with cmd
+    command:
+      cmd:
+        echo blah
+    args:
+      creates: Z
+
   - name: shell with creates check
     shell: echo blah
     args:
@@ -38,6 +45,13 @@
 
   - name: shell with inline removes
     shell: removes=Z echo blah
+
+  - name: shell with cmd
+    shell:
+      cmd:
+        echo blah
+    args:
+      creates: Z
 
 - handlers:
   - name: restart something

--- a/test/command-instead-of-shell-success.yml
+++ b/test/command-instead-of-shell-success.yml
@@ -25,3 +25,9 @@
 
   - name: use shell generator
     shell: ls foo{.txt,.xml}
+
+  - name: use shell with cmd
+    shell:
+      cmd: |
+        set -x
+        ls foo?

--- a/test/env-vars-in-command-success.yml
+++ b/test/env-vars-in-command-success.yml
@@ -14,3 +14,8 @@
 
   - name: commands can have equals in them
     command: echo "==========="
+
+  - name: commands with cmd
+    command:
+      cmd:
+        echo "-------"


### PR DESCRIPTION
At some point, ansible grew a hidden argument to shell/command tasks,
the 'cmd' argument. History found at
https://github.com/ansible/ansible/issues/12856

Our project is making use of the cmd argument so that our shell bits do
not get jinjad, so that we can use a here doc in the command.
Unfortunately this was tripping up various tests in ansible-lint, and we
had to ignore the files, which let other errors creep in. Thus this
change adds the type of syntax we use to the test yaml files and updates
the tests to propery handle them.

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>