### PR TITLE
Fix typos in rules description.

### DIFF
--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -26,7 +26,7 @@ import six
 class OctalPermissionsRule(AnsibleLintRule):
     id = 'ANSIBLE0009'
     shortdesc = 'Octal file permissions must contain leading zero'
-    description = 'Numeric file permissions without leading zero can behave' + \
+    description = 'Numeric file permissions without leading zero can behave ' + \
         'in unexpected ways. See ' + \
         'http://docs.ansible.com/ansible/file_module.html'
     tags = ['formatting']

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -26,8 +26,8 @@ from ansiblelint import AnsibleLintRule
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
     id = 'ANSIBLE0015'
     shortdesc = 'Using bare variables is deprecated'
-    description = 'Using bare variables is deprecated. Update your' + \
-        'playbooks so that the environment value uses the full variable' + \
+    description = 'Using bare variables is deprecated. Update your ' + \
+        'playbooks so that the environment value uses the full variable ' + \
         'syntax ("{{your_variable}}").'
     tags = ['formatting', 'deprecated']
 


### PR DESCRIPTION
Fix Typo in OctalPermissionRule description
Fix Typo in UsingBareVariableIsDeprecatedRule description