### PR TITLE
Issue #283: Configuration file for ansible-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 # Unit test / coverage reports
 .tox
+
+# Needed for CLI tests
+.sandbox

--- a/README.md
+++ b/README.md
@@ -222,6 +222,32 @@ As of version 2.4.0, ansible-lint now works just on roles (this is useful
 for CI of roles)
 
 
+Configuration File
+==================
+
+Ansible-lint supports local configuration via a `.ansible-lint` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.
+
+The following values are supported and function identically to their CLI counterparts.
+
+```yaml
+exclude:
+  - ./my/excluded/directory/
+  - ./my/other/excluded/directory/
+  - ./last/excluded/directory/
+parseable: true
+quiet: true
+rulesdir:
+  - ./rule/directory/
+skip_list:
+  - skip_this_tag
+  - and_this_one_too
+tags:
+  - run_this_tag
+use_default_rules: true
+verbosity: 1
+```
+
+
 Pre-commit
 ==========
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Options:
                         repeatable.
   --force-color         Try force colored output (relying on ansible's code)
   --nocolor             disable colored output
+  -F F                  Specify configuration file to use.  Defaults to
+                          ".ansible-lint"
 ```
 
 False positives
@@ -225,7 +227,7 @@ for CI of roles)
 Configuration File
 ==================
 
-Ansible-lint supports local configuration via a `.ansible-lint` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.
+Ansible-lint supports local configuration via a `.ansible-lint` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.  The configuration file location can also be overridden via the `-F path/to/file` CLI flag.
 
 The following values are supported and function identically to their CLI counterparts.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Options:
                         repeatable.
   --force-color         Try force colored output (relying on ansible's code)
   --nocolor             disable colored output
-  -F /path/to/file      Specify configuration file to use.  Defaults to
+  -c /path/to/file      Specify configuration file to use.  Defaults to
                           ".ansible-lint"
 ```
 
@@ -227,7 +227,7 @@ for CI of roles)
 Configuration File
 ==================
 
-Ansible-lint supports local configuration via a `.ansible-lint` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.  The configuration file location can also be overridden via the `-F path/to/file` CLI flag.
+Ansible-lint supports local configuration via a `.ansible-lint` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.  The configuration file location can also be overridden via the `-c path/to/file` CLI flag.
 
 The following values are supported and function identically to their CLI counterparts.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Options:
                         repeatable.
   --force-color         Try force colored output (relying on ansible's code)
   --nocolor             disable colored output
-  -F F                  Specify configuration file to use.  Defaults to
+  -F /path/to/file      Specify configuration file to use.  Defaults to
                           ".ansible-lint"
 ```
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,10 @@ Ansible-lint supports local configuration via a `.ansible-lint` configuration fi
 
 The following values are supported and function identically to their CLI counterparts.
 
+If a value is provided on both the command line and via a config file, the values will be merged (if a list like `exclude_paths`), or the "True" value will be preferred, in the case of something like `quiet`.
+
 ```yaml
-exclude:
+exclude_paths:
   - ./my/excluded/directory/
   - ./my/other/excluded/directory/
   - ./last/excluded/directory/

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -35,31 +35,20 @@ import yaml
 import os
 
 
-class Configuration:
-    def __init__(self):
-        self.config = None
+def load_config(config_file):
+    config_path = config_file if config_file else ".ansible-lint"
 
-        args = sys.argv[1:]
-        config_path = args[args.index("-F") + 1] if "-F" in args else ".ansible-lint"
+    if os.path.exists(config_path):
+        with open(config_path, "r") as stream:
+            try:
+                return yaml.load(stream)
+            except yaml.YAMLError:
+                pass
 
-        if os.path.exists(config_path):
-            with open(config_path, "r") as stream:
-                try:
-                    self.config = yaml.load(stream)
-                except yaml.YAMLError:
-                    pass
-
-    def config_or_default(self, attr, default):
-        if self.config is not None:
-            if attr in self.config:
-                return self.config[attr]
-
-        return default
+    return None
 
 
 def main():
-
-    config = Configuration()
 
     formatter = formatters.Formatter()
 
@@ -69,34 +58,35 @@ def main():
     parser.add_option('-L', dest='listrules', default=False,
                       action='store_true', help="list all the rules")
     parser.add_option('-q', dest='quiet',
-                      default=config.config_or_default("quiet", False),
+                      default=False,
                       action='store_true',
                       help="quieter, although not silent output")
     parser.add_option('-p', dest='parseable',
-                      default=config.config_or_default("parseable", False),
+                      default=False,
                       action='store_true',
                       help="parseable output in the format of pep8")
     parser.add_option('-r', action='append', dest='rulesdir',
-                      default=config.config_or_default("rulesdir", []), type='str',
+                      default=[], type='str',
                       help="specify one or more rules directories using "
                            "one or more -r arguments. Any -r flags override "
                            "the default rules in %s, unless -R is also used."
                            % ansiblelint.default_rulesdir)
     parser.add_option('-R', action='store_true',
-                      default=config.config_or_default("use_default_rules", False),
+                      default=False,
                       dest='use_default_rules',
                       help="Use default rules in %s in addition to any extra "
                            "rules directories specified with -r. There is "
                            "no need to specify this if no -r flags are used"
                            % ansiblelint.default_rulesdir)
     parser.add_option('-t', dest='tags',
-                      default=config.config_or_default("tags", []),
+                      action='append',
+                      default=[],
                       help="only check rules whose id/tags match these values")
     parser.add_option('-T', dest='listtags', action='store_true',
                       help="list all the tags")
     parser.add_option('-v', dest='verbosity', action='count',
                       help="Increase verbosity level",
-                      default=config.config_or_default("verbosity", 0))
+                      default=0)
     parser.add_option('-x', dest='skip_list', default=[],
                       help="only check rules whose id/tags do not " +
                       "match these values")
@@ -110,9 +100,38 @@ def main():
     parser.add_option('--exclude', dest='exclude_paths', action='append',
                       help='path to directories or files to skip. This option'
                            ' is repeatable.',
-                      default=config.config_or_default("exclude", []))
+                      default=[])
     parser.add_option('-F', help='Specify configuration file to use.  Defaults to ".ansible-lint"')
     options, args = parser.parse_args(sys.argv[1:])
+
+    config = load_config(options.F)
+
+    if config:
+        if 'quiet' in config:
+            options.quiet = options.quiet or config['quiet']
+
+        if 'parseable' in config:
+            options.parseable = options.parseable or config['parseable']
+
+        if 'use_default_rules' in config:
+            options.use_default_rules = \
+                options.use_default_rules or config['use_default_rules']
+
+        if 'verbosity' in config:
+            options.verbosity = options.verbosity + config['verbosity']
+
+        if 'exclude_paths' in config:
+            options.exclude_paths = \
+                options.exclude_paths + config['exclude_paths']
+
+        if 'rulesdir' in config:
+            options.rulesdir = options.rulesdir + config['rulesdir']
+
+        if 'skip_list' in config:
+            options.skip_list = options.skip_list + config['skip_list']
+
+        if 'tags' in config:
+            options.tags = options.tags + config['tags']
 
     if options.quiet:
         formatter = formatters.QuietFormatter()

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -101,10 +101,10 @@ def main():
                       help='path to directories or files to skip. This option'
                            ' is repeatable.',
                       default=[])
-    parser.add_option('-F', help='Specify configuration file to use.  Defaults to ".ansible-lint"')
+    parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".ansible-lint"')
     options, args = parser.parse_args(sys.argv[1:])
 
-    config = load_config(options.F)
+    config = load_config(options.c)
 
     if config:
         if 'quiet' in config:

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -114,15 +114,13 @@ def main():
             options.parseable = options.parseable or config['parseable']
 
         if 'use_default_rules' in config:
-            options.use_default_rules = \
-                options.use_default_rules or config['use_default_rules']
+            options.use_default_rules = options.use_default_rules or config['use_default_rules']
 
         if 'verbosity' in config:
             options.verbosity = options.verbosity + config['verbosity']
 
         if 'exclude_paths' in config:
-            options.exclude_paths = \
-                options.exclude_paths + config['exclude_paths']
+            options.exclude_paths = options.exclude_paths + config['exclude_paths']
 
         if 'rulesdir' in config:
             options.rulesdir = options.rulesdir + config['rulesdir']

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -31,6 +31,25 @@ import ansiblelint.formatters as formatters
 import six
 from ansiblelint import RulesCollection
 from ansiblelint.version import __version__
+import yaml
+import os
+
+config = None
+
+if os.path.exists(".ansible-lint"):
+    with open(".ansible-lint", "r") as stream:
+        try:
+            config = yaml.load(stream)
+        except yaml.YAMLError as exc:
+            pass
+
+
+def config_or_default(attr, default):
+    if config is not None:
+        if attr in config:
+            return config[attr]
+
+    return default
 
 
 def main():
@@ -42,29 +61,35 @@ def main():
 
     parser.add_option('-L', dest='listrules', default=False,
                       action='store_true', help="list all the rules")
-    parser.add_option('-q', dest='quiet', default=False, action='store_true',
+    parser.add_option('-q', dest='quiet',
+                      default=config_or_default("quiet", False),
+                      action='store_true',
                       help="quieter, although not silent output")
     parser.add_option('-p', dest='parseable',
-                      default=False, action='store_true',
+                      default=config_or_default("parseable", False),
+                      action='store_true',
                       help="parseable output in the format of pep8")
     parser.add_option('-r', action='append', dest='rulesdir',
-                      default=[], type='str',
+                      default=config_or_default("rulesdir", []), type='str',
                       help="specify one or more rules directories using "
                            "one or more -r arguments. Any -r flags override "
                            "the default rules in %s, unless -R is also used."
                            % ansiblelint.default_rulesdir)
-    parser.add_option('-R', action='store_true', default=False,
+    parser.add_option('-R', action='store_true',
+                      default=config_or_default("use_default_rules", False),
                       dest='use_default_rules',
                       help="Use default rules in %s in addition to any extra "
                            "rules directories specified with -r. There is "
                            "no need to specify this if no -r flags are used"
                            % ansiblelint.default_rulesdir)
-    parser.add_option('-t', dest='tags', default=[],
+    parser.add_option('-t', dest='tags',
+                      default=config_or_default("tags", []),
                       help="only check rules whose id/tags match these values")
     parser.add_option('-T', dest='listtags', action='store_true',
                       help="list all the tags")
     parser.add_option('-v', dest='verbosity', action='count',
-                      help="Increase verbosity level", default=0)
+                      help="Increase verbosity level",
+                      default=config_or_default("verbosity", 0))
     parser.add_option('-x', dest='skip_list', default=[],
                       help="only check rules whose id/tags do not " +
                       "match these values")
@@ -77,7 +102,8 @@ def main():
                       help="Try force colored output (relying on ansible's code)")
     parser.add_option('--exclude', dest='exclude_paths', action='append',
                       help='path to directories or files to skip. This option'
-                           ' is repeatable.')
+                           ' is repeatable.',
+                      default=config_or_default("exclude", []))
     options, args = parser.parse_args(sys.argv[1:])
 
     if options.quiet:

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -1,0 +1,65 @@
+import unittest
+from subprocess import Popen, PIPE
+import os
+import shutil
+import yaml
+
+
+class TestCommandLineInvocationSameAsConfig(unittest.TestCase):
+    def setUp(self):
+        if os.path.exists(".sandbox"):
+            shutil.rmtree(".sandbox")
+
+        os.makedirs(".sandbox")
+
+    def run_ansible_lint(self, args=False, config=None):
+        command = "cd .sandbox; ../bin/ansible-lint ../test/skiptasks.yml"
+        if args:
+            command += " " + args
+
+        if config:
+            with open(".sandbox/.ansible-lint", "w") as outfile:
+                yaml.dump(config, outfile, default_flow_style=False)
+
+        result, err = Popen(
+            [command],
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+            shell=True
+        ).communicate()
+
+        self.assertFalse(err)
+
+        return result
+
+    def assert_config_for(self, cli_arg, config):
+        with_arg = self.run_ansible_lint(args=cli_arg)
+        with_config = self.run_ansible_lint(config=config)
+
+        self.assertEqual(with_arg, with_config)
+
+    def test_parseable_as_config(self):
+        self.assert_config_for("-p", dict(parseable=True))
+
+    def test_quiet_as_config(self):
+        self.assert_config_for("-q", dict(quiet=True))
+
+    def test_rulesdir_as_config(self):
+        self.assert_config_for("-r ../test/rules/", dict(rulesdir=["../test/rules/"]))
+
+    def test_use_default_rules(self):
+        self.assert_config_for("-R -r ../test/rules/", dict(rulesdir=["../test/rules"],
+                                                            use_default_rules=True))
+
+    def test_tags(self):
+        self.assert_config_for("-t skip_ansible_lint", dict(tags=["skip_ansible_lint"]))
+
+    def test_verbosity(self):
+        self.assert_config_for("-v", dict(verbosity=1))
+
+    def test_skip_list(self):
+        self.assert_config_for("-x bad_tag", dict(skip_list=["bad_tag"]))
+
+    def test_exclude(self):
+        self.assert_config_for("--exclude ../test/", dict(exclude=["../test/"]))

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -74,7 +74,7 @@ class TestCommandLineInvocationSameAsConfig(unittest.TestCase):
         with open(".sandbox/subdir/ansible-config.yml", "w") as outfile:
             yaml.dump(dict(verbosity=1), outfile, default_flow_style=False)
 
-        diff_config = self.run_ansible_lint(args="-F ./subdir/ansible-config.yml")
+        diff_config = self.run_ansible_lint(args="-c ./subdir/ansible-config.yml")
         no_config = self.run_ansible_lint(args="-v")
 
         self.assertEqual(diff_config, no_config)

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -29,7 +29,7 @@ class TestCommandLineInvocationSameAsConfig(unittest.TestCase):
             shell=True
         ).communicate()
 
-        self.assertFalse(err, "Expected no error but was " + err)
+        self.assertFalse(err, "Expected no error but was " + str(err))
 
         return result
 

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -29,7 +29,7 @@ class TestCommandLineInvocationSameAsConfig(unittest.TestCase):
             shell=True
         ).communicate()
 
-        self.assertFalse(err)
+        self.assertFalse(err, "Expected no error but was " + err)
 
         return result
 
@@ -62,7 +62,7 @@ class TestCommandLineInvocationSameAsConfig(unittest.TestCase):
         self.assert_config_for("-x bad_tag", dict(skip_list=["bad_tag"]))
 
     def test_exclude(self):
-        self.assert_config_for("--exclude ../test/", dict(exclude=["../test/"]))
+        self.assert_config_for("--exclude ../test/", dict(exclude_paths=["../test/"]))
 
     def test_config_can_be_overridden(self):
         no_override = self.run_ansible_lint(args="-t bad_tag")


### PR DESCRIPTION
I'm trying my hand at adding the configuration file mentioned in issue #283.  I'm a newbie to Python so please go easy on me.  All code was written with TDD.  I wrote the tests to invoke ansible-lint as a subprocess and compare the output of the CLI arguments to its equivalent config file.  I wasn't sure if there was a better way to write them but I'm open to suggestions.

Please let me know any concerns or suggestions.