### PR TITLE
ANSIBLE0012: also allow register with command.

### DIFF
--- a/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -37,5 +37,6 @@ class CommandHasChangesCheckRule(AnsibleLintRule):
             if task["action"]["__ansible_module__"] in self._commands:
                 return 'changed_when' not in task and \
                     'when' not in task and \
+                    'register' not in task and \
                     'creates' not in task['action'] and \
                     'removes' not in task['action']


### PR DESCRIPTION
In my playbook I need to gather some system values by running custom commands and registering them into variables. 
I can not use ansible-facts for this.
Example use case:
```YAML
- name: Get ansible-lint version
  command: ansible-lint --version
  register: ansible_lint_version_output

- name: Register ansible-lint version
  set_fact:
    ansible_lint_version: ansible_lint_version_output.stdout
```
Ansible-lint sees this as improper use of the command statement. So I have to add the skip_ansible_lint tag to these tasks currently.

With this pull request these tasks are also allowed.