### PR TITLE
added test rule to check for key=value format

### DIFF
--- a/lib/ansiblelint/rules/NoKeyValueFormat.py
+++ b/lib/ansiblelint/rules/NoKeyValueFormat.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from ansiblelint import AnsibleLintRule
+import re
+
+
+class NoKeyValueFormat(AnsibleLintRule):
+    id = 'ANSIBLE0003'
+    shortdesc = 'Dont use key=value format for tasks'
+    description = 'You should use native YAML syntax instead of key=value format'
+    tags = ['formatting']
+
+    def match(self, file, line):
+        if "name:" in line:
+            return False
+        if "when:" in line:
+            return False
+        pattern = re.compile('[a-zA-Z0-9_.-]*=[a-zA-Z0-9_.-]*')
+        if pattern.findall(line):
+            return True


### PR DESCRIPTION
I wrote this quick&dirty rule to check for `key=value` format to try to enforce native yaml syntax. More details about this in this issue https://github.com/willthames/ansible-lint/issues/297

I have written this in 15min and this is my first time writing an ansible-lint rule so most probably this code is not the right way to do it but it seems to do the trick for me. these are same sample outputs:

```
Examining tasks/main.yml of type playbook
[ANSIBLE0003] Dont use key=value format for tasks
tasks/main.yml:8
    timezone: name="{{ ntp_timezone }}"

[ANSIBLE0003] Dont use key=value format for tasks
/tasks/main.yml:11
    yum: name=ntp state=present
```

when processing this test playbook:

```
  - name: set timezone
    timezone: name="{{ ntp_timezone }}"

  - name: Install ntp
    yum: name=ntp state=present

  - name: Copy ntp conf file
    template:
      src: etc/ntp.conf.j2
      dest: /etc/ntp.conf
    notify: restart ntp
    tags: configs_sync
    when: ntp_timezone == 'lelele'

  - name: Start and enable the ntp service
    service:
      name: ntpd
      state: started
      enabled: true
```

Any suggestion is appreciated. 

Any chance to get this merged once it's properly done?