### PR TITLE
Fix for Python 2.6

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -492,7 +492,7 @@ def get_action_tasks(yaml, file):
     tasks[:] = [task for task in tasks if all(k not in task for k in block_rescue_always)]
 
     return [task for task in tasks if
-            {'include', 'include_tasks', 'import_tasks'}.isdisjoint(task.keys())]
+            set(['include', 'include_tasks', 'import_tasks']).isdisjoint(task.keys())]
 
 
 def get_normalized_tasks(yaml, file):


### PR DESCRIPTION
Python 2.6 does not offer the non-empty set shortcut statement with {}, which was introduced in Python 2.7: "As of Python 2.7, non-empty sets (not frozensets) can be created by placing a comma-separated list of elements within braces, for example: {'jack', 'sjoerd'}, in addition to the set constructor."

Unfortunately, Python 2.6 is still the default on RHEL6 systems.