### PR TITLE
OctalPermissionsRule: Fix false positive for octal directory permissions with just execute bit set

### DIFF
--- a/test/octalpermissions-success.yml
+++ b/test/octalpermissions-success.yml
@@ -23,3 +23,9 @@
 
     - name:  permissions test success (0777)
       file: path=baz mode=u+rwx
+
+    - name: folder octal permissions success (0711)
+      file:
+        path: baz
+        state: directory
+        mode: 0711


### PR DESCRIPTION
It is relatively common to want to set just the execute bit for group or world for directories (e.g. `0711` or `0751`) to allow user access to paths below without being able to list the directory contents.  This however
causes a task to be flagged as violating `ANSIBLE0009` even if a valid octal permissions value was used.

Bypass the group and world execute only permission checks just when `state=directory` is used with the file module.

Resolves #235.