### PR TITLE
[WIP] support to specify tasks, handlers, metas file

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -188,7 +188,13 @@ class Runner(object):
             self.playbooks.add((playbook, 'role'))
             self.playbook_dir = playbook
         else:
-            self.playbooks.add((playbook, 'playbook'))
+            # assume tasks, handlers or meta file if the dir name moved up one is that.
+            dirname = os.path.basename(os.path.dirname(os.path.abspath(playbook)))
+            if dirname in ['tasks', 'handlers', 'meta']:
+                self.playbooks.add((playbook, dirname))
+            else:
+                self.playbooks.add((playbook, 'playbook'))
+
             self.playbook_dir = os.path.dirname(playbook)
         self.tags = tags
         self.skip_list = skip_list


### PR DESCRIPTION
# please support the arguments of task, handler, meta files

Although I try to use ansible-lint with [pre-commit](https://github.com/pre-commit/pre-commit), I'm having a problem.

The problem is that in case I staged only task, handler or meta files,
ansible-lint don't check these files.

In my understanding, there are two causes.

* First is that pre-commit execute ansible-lint for only staged files. Since unstaged playbook is not checked, it doesn't execute ansible-lint for unstaged playbook.

* Second is that ansible-lint don't support the argument of task, handler, meta files. ansible-lint is now only support playbook and role directory so that it can't check these files.

I think to solve the second cause is better because ansible-lint can support more files.
So I want ansible-lint to support arguments of task, handler, meta files.

Please see my WIP code.
Since I'm not familiar with ansible-lint, I think my code is not enough to merge.

First, I want to know what you think about this idea.
If there are similar issues or better ideas, let me know.

Thanks