### PR TITLE
WIP: Octal permissions

### DIFF
--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -41,7 +41,9 @@ class OctalPermissionsRule(AnsibleLintRule):
         if task["action"]["__ansible_module__"] in self._modules:
             mode = task['action'].get('mode', None)
             if isinstance(mode, six.string_types) and self.mode_regex.match(mode):
-                return not self.valid_mode_regex.match(mode)
+                if not self.valid_mode_regex.match(mode):
+                    return True
+                mode = int(mode.strip(), 8)
             if isinstance(mode, int):
                 # sensible file permission modes don't
                 # have write bit set when read bit is

--- a/test/octalpermissions-success.yml
+++ b/test/octalpermissions-success.yml
@@ -21,11 +21,16 @@
     - name: octal permissions test success (0777)
       file: path=baz mode=0777
 
-    - name: octal permissions test success (0711)
+    - name: octal permissions test success [1/2] (0711)
       file: path=baz mode=0711
+
+    - name: octal permissions test success [2/2] (0711)
+      file:
+        path: baz
+        mode: 0711
 
     - name: octal permissions test success (0710)
       file: path=baz mode=0710
 
-    - name:  permissions test success (0777)
+    - name: permissions test success (0777)
       file: path=baz mode=u+rwx


### PR DESCRIPTION
`mode=0755`, `mode: "0755"` and `mode: 0755` appear to be treated differently.
Convert the string to its octal notation if it's numerical to treat them equally and check it for sensible file permission modes too.

This breaks the current tests (on my setup) so either the conversion from string to octal is wrong, or the sensible file permission check is wrong.

Also, would it make sense to move the check if the permissions are sensible to a separate rule? (This would make it possible to check for leading zeros but ignore less sensible permissions.)