### PR TITLE
Migrate to new PyPI website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible-lint
 ansible-lint checks playbooks for practices and behaviour that could
 potentially be improved
 
-[![PyPI version](https://img.shields.io/pypi/v/ansible-lint.svg)](https://pypi.python.org/pypi/ansible-lint)
+[![PyPI version](https://img.shields.io/pypi/v/ansible-lint.svg)](https://pypi.org/project/ansible-lint/)
 [![Build Status](https://travis-ci.org/willthames/ansible-lint.svg?branch=master)](https://travis-ci.org/willthames/ansible-lint)
 
 Setup


### PR DESCRIPTION
According to [1], the PyPI website of pypi.python.org has changed
to https://pypi.org. This patch updates all references to the
legacy site.

[1] https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Signed-off-by: Eric Brown <browne@vmware.com>