### PR TITLE
Fix comma-separated skip_list arguments

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -163,7 +163,7 @@ def main():
 
     skip = set()
     for s in options.skip_list:
-         skip.add(*s.split(','))
+         skip.update(s.split(','))
     options.skip_list = frozenset(skip)
 
     playbooks = set(args)


### PR DESCRIPTION
skip.add only takes one element - skip.update allows for a set
to be updated with multiple elements