### PR TITLE
Output results in `FILENAME:LINENUM:` format

### DIFF
--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
 class Formatter(object):
 
     def format(self, match, colored=False):
-        formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
+        formatstr = u"{0} {1}\n{2}:{3}:\n{4}\n"
         if colored:
             color.ANSIBLE_COLOR = True
             return formatstr.format(color.stringc(u"[{0}]".format(match.rule.id), 'bright red'),


### PR DESCRIPTION
AFAIK, conventionally compilers, grep programs and linters use `FILENAME:LINENUM:[COLUMNNUM:]` format to point out where something interesting happen in files.

- [pep8](https://pypi.org/project/pep8/) emits lines like `optparse.py:69:11: E401 multiple imports on one line` to indicate where violations are found
- `grep -nH` emits lines like `README.md:4:ansible-lint checks playbooks for practices and behaviour that could` where the texts are found.

And some applications expect this format of output.
For example, I usually use Emacs, and texts in this format is "clickable" in `compile` feature: press enter on this to jump to the point, which makes it much easier to check or/and fix codes.

So, at least Emacs users (or at least me!) would be happy if this PR had been merged XD
