### PR TITLE
Fix task files included in roles not parsed

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -207,6 +207,8 @@ def play_children(basedir, item, parent_type, playbook_dir):
         'roles': _roles_children,
         'dependencies': _roles_children,
         'handlers': _taskshandlers_children,
+        'include_tasks': _include_children,
+        'import_tasks': _include_children,
     }
     (k, v) = item
     play_library = os.path.join(os.path.abspath(basedir), 'library')

--- a/test/TestTaskIncludes.py
+++ b/test/TestTaskIncludes.py
@@ -49,3 +49,10 @@ class TestTaskIncludes(unittest.TestCase):
         runner = Runner(self.rules, filename, [], [], [])
         runner.run()
         self.assertEqual(len(runner.playbooks), 3)
+
+    @unittest.skipIf(parse_version(ansible.__version__) < parse_version('2.4'), "not supported with ansible < 2.4")
+    def test_include_tasks_in_role(self):
+        filename = 'test/include-import-tasks-in-role.yml'
+        runner = Runner(self.rules, filename, [], [], [])
+        runner.run()
+        self.assertEqual(len(runner.playbooks), 4)

--- a/test/include-import-tasks-in-role.yml
+++ b/test/include-import-tasks-in-role.yml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - role-with-included-imported-tasks

--- a/test/role-with-included-imported-tasks/tasks/imported_tasks.yml
+++ b/test/role-with-included-imported-tasks/tasks/imported_tasks.yml
@@ -1,0 +1,2 @@
+- name: This is a task that should be imported
+  ping:

--- a/test/role-with-included-imported-tasks/tasks/included_tasks.yml
+++ b/test/role-with-included-imported-tasks/tasks/included_tasks.yml
@@ -1,0 +1,2 @@
+- name: This is a task that should be included
+  ping:

--- a/test/role-with-included-imported-tasks/tasks/main.yml
+++ b/test/role-with-included-imported-tasks/tasks/main.yml
@@ -1,0 +1,2 @@
+- include_tasks: included_tasks.yml
+- import_tasks: imported_tasks.yml


### PR DESCRIPTION
Task files included using `include_tasks` or `import_tasks` in roles are not parsed.
They will now be parsed using the _include_children method.