### PR TITLE
Proposal: Category tagging and id edits for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ rulesdir:
 skip_list:
   - skip_this_tag
   - and_this_one_too
+  - skip_this_id
+  - '401'
 tags:
   - run_this_tag
 use_default_rules: true

--- a/RULE_DOCS.md
+++ b/RULE_DOCS.md
@@ -1,0 +1,28 @@
+| id                                                       | sample message                                           |
+|----------------------------------------------------------|----------------------------------------------------------|
+| **E1**                                                   | *deprecated*                                             |
+| E101                                                     | Deprecated always_run                                    |
+| E102                                                     | No Jinja2 in when                                        |
+| E103                                                     | Deprecated sudo                                          |
+| E104                                                     | Using bare variables is deprecated                       |
+|                                                          |                                                          |
+| **E2**                                                   | *formatting*                                             |
+| E201                                                     | Trailing whitespace                                      |
+| E202                                                     | Octal file permissions must contain leading zero         |
+|                                                          |                                                          |
+| **E3**                                                   | *command-shell*                                          |
+| E301                                                     | Commands should not change things if nothing needs doing |
+| E302                                                     | Using command rather than an argument to e.g. file       |
+| E303                                                     | Using command rather than module                         |
+| E304                                                     | Environment variables don't work as part of command      |
+| E305                                                     | Use shell only when shell functionality is required      |
+|                                                          |                                                          |
+| **E4**                                                   | *module*                                                 |
+| E401                                                     | Git checkouts must contain explicit version              |
+| E402                                                     | Mercurial checkouts must contain explicit revision       |
+| E403                                                     | Package installs should not use latest                   |
+|                                                          |                                                          |
+| **E5**                                                   | *task*                                                   |
+| E501                                                     | become_user requires become to work as expected          |
+| E502                                                     | All tasks should be named                                |
+| E503                                                     | Tasks that run when changed should likely be handlers    |

--- a/lib/ansiblelint/generate_docs.py
+++ b/lib/ansiblelint/generate_docs.py
@@ -5,6 +5,7 @@ import importlib
 from inspect import getmembers, ismodule, isclass
 import rules
 from ansiblelint import AnsibleLintRule
+from functools import reduce
 
 
 def main():

--- a/lib/ansiblelint/generate_docs.py
+++ b/lib/ansiblelint/generate_docs.py
@@ -1,0 +1,73 @@
+'''Script to generate rule table markdown documentation.'''
+
+import os
+import importlib
+from inspect import getmembers, ismodule, isclass
+import rules
+from ansiblelint import AnsibleLintRule
+
+
+def main():
+    import_all_rules()
+    all_rules = get_serialized_rules()
+
+    grid = [['id', 'sample message']]
+    for d in all_rules:
+        if d['id'].endswith('01'):
+            if not d['id'].endswith('101'):
+                grid.append(['', ''])
+            grid.append(['**E{}**'.format(d['id'][-3:-2]),
+                         '*{}*'.format(d['first_tag'])])
+        grid.append(['E{}'.format(d['id']), d['shortdesc']])
+
+    filename = '../../RULE_DOCS.md'
+    with open(filename, 'w') as file:
+        file.write(make_table(grid))
+        print('{} file written'.format(filename))
+
+
+def import_all_rules():
+    for module in list(os.walk('rules'))[0][2]:
+        if module == '__init__.py' or module[-3:] != '.py':
+            continue
+        module = 'rules.{}'.format(module[:-3])
+        importlib.import_module(module)
+
+
+def get_serialized_rules():
+    mod_list = [m[1] for m in getmembers(rules) if ismodule(m[1])]
+    class_list = []
+    for mod in mod_list:
+        class_temp = [m[1] for m in getmembers(mod) if isclass(m[1])]
+        class_temp = [c for c in class_temp if c is not AnsibleLintRule]
+        class_list.extend(class_temp)
+
+    all_rules = []
+    for c in class_list:
+        d = {'id': c.id, 'shortdesc': c.shortdesc, 'first_tag': c.tags[0]}
+        all_rules.append(d)
+    all_rules = sorted(all_rules, key=lambda k: k['id'])
+    return all_rules
+
+
+def make_table(grid):
+    cell_width = 2 + max(reduce(lambda x, y: x+y,
+                         [[len(item) for item in row] for row in grid], []))
+    num_cols = len(grid[0])
+    block = ''
+    header = True
+    for row in grid:
+        block = block + '| ' + '| '.join([normalize_cell(x, cell_width-1)
+                                          for x in row]) + '|\n'
+        if header:
+            block = block + num_cols*('|' + (cell_width)*'-') + '|\n'
+        header = False
+    return block
+
+
+def normalize_cell(string, length):
+    return string + ((length - len(string)) * ' ')
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -25,7 +25,7 @@ class AlwaysRunRule(AnsibleLintRule):
     id = '101'
     shortdesc = 'Deprecated always_run'
     description = 'Instead of always_run, use check_mode.'
-    tags = ['deprecated']
+    tags = ['deprecated', 'ANSIBLE0018']
 
     def matchtask(self, file, task):
         return 'always_run' in task

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -22,7 +22,7 @@ from ansiblelint import AnsibleLintRule
 
 
 class AlwaysRunRule(AnsibleLintRule):
-    id = 'ANSIBLE0018'
+    id = '101'
     shortdesc = 'Deprecated always_run'
     description = 'Instead of always_run, use check_mode.'
     tags = ['deprecated']

--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -26,11 +26,11 @@ def _become_user_without_become(data):
 
 
 class BecomeUserWithoutBecomeRule(AnsibleLintRule):
-    id = 'ANSIBLE0017'
+    id = '501'
     shortdesc = 'become_user requires become to work as expected'
     description = 'become_user without become will not actually change ' \
                   'user'
-    tags = ['oddity']
+    tags = ['task', 'oddity']
 
     def matchplay(self, file, data):
         if file['type'] == 'playbook' and _become_user_without_become(data):

--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -30,7 +30,7 @@ class BecomeUserWithoutBecomeRule(AnsibleLintRule):
     shortdesc = 'become_user requires become to work as expected'
     description = 'become_user without become will not actually change ' \
                   'user'
-    tags = ['task', 'oddity']
+    tags = ['task', 'oddity', 'ANSIBLE0017']
 
     def matchplay(self, file, data):
         if file['type'] == 'playbook' and _become_user_without_become(data):

--- a/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -22,13 +22,13 @@ from ansiblelint import AnsibleLintRule
 
 
 class CommandHasChangesCheckRule(AnsibleLintRule):
-    id = 'ANSIBLE0012'
+    id = '301'
     shortdesc = 'Commands should not change things if nothing needs doing'
     description = 'Commands should either read information (and thus set ' \
                   'changed_when) or not do something if it has already been ' \
                   'done (using creates/removes) or only do it if another ' \
                   'check has a particular result (when)'
-    tags = ['idempotency']
+    tags = ['command-shell', 'idempotency']
 
     _commands = ['command', 'shell', 'raw']
 

--- a/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -28,7 +28,7 @@ class CommandHasChangesCheckRule(AnsibleLintRule):
                   'changed_when) or not do something if it has already been ' \
                   'done (using creates/removes) or only do it if another ' \
                   'check has a particular result (when)'
-    tags = ['command-shell', 'idempotency']
+    tags = ['command-shell', 'idempotency', 'ANSIBLE0012']
 
     _commands = ['command', 'shell', 'raw']
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -39,7 +39,7 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
     shortdesc = 'Using command rather than an argument to e.g. file'
     description = 'Executing a command when there is are arguments to modules ' + \
                   'is generally a bad idea'
-    tags = ['command-shell', 'resources']
+    tags = ['command-shell', 'resources', 'ANSIBLE0007']
 
     _commands = ['command', 'shell', 'raw']
     _arguments = {'chown': 'owner', 'chmod': 'mode', 'chgrp': 'group',

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -35,11 +35,11 @@ except ImportError:
 
 
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
-    id = 'ANSIBLE0007'
+    id = '302'
     shortdesc = 'Using command rather than an argument to e.g. file'
     description = 'Executing a command when there is are arguments to modules ' + \
                   'is generally a bad idea'
-    tags = ['resources']
+    tags = ['command-shell', 'resources']
 
     _commands = ['command', 'shell', 'raw']
     _arguments = {'chown': 'owner', 'chmod': 'mode', 'chgrp': 'group',

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -35,11 +35,11 @@ except ImportError:
 
 
 class CommandsInsteadOfModulesRule(AnsibleLintRule):
-    id = 'ANSIBLE0006'
+    id = '303'
     shortdesc = 'Using command rather than module'
     description = 'Executing a command when there is an Ansible module ' + \
                   'is generally a bad idea'
-    tags = ['resources']
+    tags = ['command-shell', 'resources']
 
     _commands = ['command', 'shell']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -39,7 +39,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     shortdesc = 'Using command rather than module'
     description = 'Executing a command when there is an Ansible module ' + \
                   'is generally a bad idea'
-    tags = ['command-shell', 'resources']
+    tags = ['command-shell', 'resources', 'ANSIBLE0006']
 
     _commands = ['command', 'shell']
     _modules = {'git': 'git', 'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',

--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -27,7 +27,7 @@ class EnvVarsInCommandRule(AnsibleLintRule):
     shortdesc = "Environment variables don't work as part of command"
     description = 'Environment variables should be passed to shell or ' \
                   'command through environment argument'
-    tags = ['command-shell', 'bug']
+    tags = ['command-shell', 'bug', 'ANSIBLE0014']
 
     expected_args = ['chdir', 'creates', 'executable', 'removes', 'stdin', 'warn',
                      'cmd', '__ansible_module__', '__ansible_arguments__',

--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -23,11 +23,11 @@ from ansiblelint.utils import LINE_NUMBER_KEY, FILENAME_KEY
 
 
 class EnvVarsInCommandRule(AnsibleLintRule):
-    id = 'ANSIBLE0014'
+    id = '304'
     shortdesc = "Environment variables don't work as part of command"
     description = 'Environment variables should be passed to shell or ' \
                   'command through environment argument'
-    tags = ['bug']
+    tags = ['command-shell', 'bug']
 
     expected_args = ['chdir', 'creates', 'executable', 'removes', 'stdin', 'warn',
                      'cmd', '__ansible_module__', '__ansible_arguments__',

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -22,11 +22,11 @@ from ansiblelint import AnsibleLintRule
 
 
 class GitHasVersionRule(AnsibleLintRule):
-    id = 'ANSIBLE0004'
+    id = '401'
     shortdesc = 'Git checkouts must contain explicit version'
     description = 'All version control checkouts must point to ' + \
                   'an explicit commit or tag, not just "latest"'
-    tags = ['repeatability']
+    tags = ['module', 'repeatability']
 
     def matchtask(self, file, task):
         return (task['action']['__ansible_module__'] == 'git' and

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -26,7 +26,7 @@ class GitHasVersionRule(AnsibleLintRule):
     shortdesc = 'Git checkouts must contain explicit version'
     description = 'All version control checkouts must point to ' + \
                   'an explicit commit or tag, not just "latest"'
-    tags = ['module', 'repeatability']
+    tags = ['module', 'repeatability', 'ANSIBLE0004']
 
     def matchtask(self, file, task):
         return (task['action']['__ansible_module__'] == 'git' and

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -22,12 +22,12 @@ from ansiblelint import AnsibleLintRule
 
 
 class MercurialHasRevisionRule(AnsibleLintRule):
-    id = 'ANSIBLE0005'
+    id = '402'
     shortdesc = 'Mercurial checkouts must contain explicit revision'
     description = 'All version control checkouts must point to ' + \
                   'an explicit commit or tag, not just "latest"'
 
-    tags = ['repeatability']
+    tags = ['module', 'repeatability']
 
     def matchtask(self, file, task):
         return (task['action']['__ansible_module__'] == 'hg' and

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -27,7 +27,7 @@ class MercurialHasRevisionRule(AnsibleLintRule):
     description = 'All version control checkouts must point to ' + \
                   'an explicit commit or tag, not just "latest"'
 
-    tags = ['module', 'repeatability']
+    tags = ['module', 'repeatability', 'ANSIBLE0005']
 
     def matchtask(self, file, task):
         return (task['action']['__ansible_module__'] == 'hg' and

--- a/lib/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/lib/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -10,7 +10,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
     id = '102'
     shortdesc = 'No Jinja2 in when'
     description = '"when" lines should not include Jinja2 variables'
-    tags = ['deprecated']
+    tags = ['deprecated', 'ANSIBLE0019']
 
     def _is_valid(self, when):
         if not isinstance(when, StringTypes):

--- a/lib/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/lib/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 class NoFormattingInWhenRule(AnsibleLintRule):
-    id = 'ANSIBLE0019'
+    id = '102'
     shortdesc = 'No Jinja2 in when'
     description = '"when" lines should not include Jinja2 variables'
     tags = ['deprecated']

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -24,7 +24,7 @@ import six
 
 
 class OctalPermissionsRule(AnsibleLintRule):
-    id = 'ANSIBLE0009'
+    id = '202'
     shortdesc = 'Octal file permissions must contain leading zero'
     description = 'Numeric file permissions without leading zero can behave ' + \
         'in unexpected ways. See ' + \

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -29,7 +29,7 @@ class OctalPermissionsRule(AnsibleLintRule):
     description = 'Numeric file permissions without leading zero can behave ' + \
         'in unexpected ways. See ' + \
         'http://docs.ansible.com/ansible/file_module.html'
-    tags = ['formatting']
+    tags = ['formatting', 'ANSIBLE0009']
 
     _modules = ['assemble', 'copy', 'file', 'ini_file', 'lineinfile',
                 'replace', 'synchronize', 'template', 'unarchive']

--- a/lib/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/lib/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -26,7 +26,7 @@ class PackageIsNotLatestRule(AnsibleLintRule):
     shortdesc = 'Package installs should not use latest'
     description = 'Package installs should use state=present ' + \
                   'with or without a version'
-    tags = ['module', 'repeatability']
+    tags = ['module', 'repeatability', 'ANSIBLE0010']
 
     _package_managers = ['yum', 'apt', 'dnf', 'homebrew', 'pacman', 'openbsd_package', 'pkg5',
                          'portage', 'pkgutil', 'slackpkg', 'swdepot', 'zypper', 'bundler', 'pip',

--- a/lib/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/lib/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -22,11 +22,11 @@ from ansiblelint import AnsibleLintRule
 
 
 class PackageIsNotLatestRule(AnsibleLintRule):
-    id = 'ANSIBLE0010'
+    id = '403'
     shortdesc = 'Package installs should not use latest'
     description = 'Package installs should use state=present ' + \
                   'with or without a version'
-    tags = ['repeatability']
+    tags = ['module', 'repeatability']
 
     _package_managers = ['yum', 'apt', 'dnf', 'homebrew', 'pacman', 'openbsd_package', 'pkg5',
                          'portage', 'pkgutil', 'slackpkg', 'swdepot', 'zypper', 'bundler', 'pip',

--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -2,7 +2,7 @@ from ansiblelint import AnsibleLintRule
 
 
 class SudoRule(AnsibleLintRule):
-    id = 'ANSIBLE0008'
+    id = '103'
     shortdesc = 'Deprecated sudo'
     description = 'Instead of sudo/sudo_user, use become/become_user.'
     tags = ['deprecated']

--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -5,7 +5,7 @@ class SudoRule(AnsibleLintRule):
     id = '103'
     shortdesc = 'Deprecated sudo'
     description = 'Instead of sudo/sudo_user, use become/become_user.'
-    tags = ['deprecated']
+    tags = ['deprecated', 'ANSIBLE0008']
 
     def _check_value(self, play_frag):
         results = []

--- a/lib/ansiblelint/rules/TaskHasNameRule.py
+++ b/lib/ansiblelint/rules/TaskHasNameRule.py
@@ -26,7 +26,7 @@ class TaskHasNameRule(AnsibleLintRule):
     shortdesc = 'All tasks should be named'
     description = 'All tasks should have a distinct name for readability ' + \
                   'and for --start-at-task to work'
-    tags = ['task', 'readability']
+    tags = ['task', 'readability', 'ANSIBLE0011']
 
     _nameless_tasks = ['meta', 'debug', 'include_role', 'import_role',
                        'include_tasks', 'import_tasks']

--- a/lib/ansiblelint/rules/TaskHasNameRule.py
+++ b/lib/ansiblelint/rules/TaskHasNameRule.py
@@ -22,11 +22,11 @@ from ansiblelint import AnsibleLintRule
 
 
 class TaskHasNameRule(AnsibleLintRule):
-    id = 'ANSIBLE0011'
+    id = '502'
     shortdesc = 'All tasks should be named'
     description = 'All tasks should have a distinct name for readability ' + \
                   'and for --start-at-task to work'
-    tags = ['readability']
+    tags = ['task', 'readability']
 
     _nameless_tasks = ['meta', 'debug', 'include_role', 'import_role',
                        'include_tasks', 'import_tasks']

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -25,7 +25,7 @@ class TrailingWhitespaceRule(AnsibleLintRule):
     id = '201'
     shortdesc = 'Trailing whitespace'
     description = 'There should not be any trailing whitespace'
-    tags = ['formatting']
+    tags = ['formatting', 'ANSIBLE0002']
 
     def match(self, file, line):
         return line.rstrip() != line

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -22,7 +22,7 @@ from ansiblelint import AnsibleLintRule
 
 
 class TrailingWhitespaceRule(AnsibleLintRule):
-    id = 'ANSIBLE0002'
+    id = '201'
     shortdesc = 'Trailing whitespace'
     description = 'There should not be any trailing whitespace'
     tags = ['formatting']

--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -32,7 +32,7 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
     description = 'Shell should only be used when piping, redirecting ' \
                   'or chaining commands (and Ansible would be preferred ' \
                   'for some of those!)'
-    tags = ['command-shell', 'safety']
+    tags = ['command-shell', 'safety', 'ANSIBLE0013']
 
     def matchtask(self, file, task):
         # Use unjinja so that we don't match on jinja filters

--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -27,12 +27,12 @@ def unjinja(text):
 
 
 class UseCommandInsteadOfShellRule(AnsibleLintRule):
-    id = 'ANSIBLE0013'
+    id = '305'
     shortdesc = 'Use shell only when shell functionality is required'
     description = 'Shell should only be used when piping, redirecting ' \
                   'or chaining commands (and Ansible would be preferred ' \
                   'for some of those!)'
-    tags = ['safety']
+    tags = ['command-shell', 'safety']
 
     def matchtask(self, file, task):
         # Use unjinja so that we don't match on jinja filters

--- a/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -33,7 +33,7 @@ class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
     shortdesc = 'Tasks that run when changed should likely be handlers'
     description = "If a task has a `when: result.changed` setting, it's effectively " \
                   "acting as a handler"
-    tags = ['task', 'behaviour']
+    tags = ['task', 'behaviour', 'ANSIBLE0016']
 
     def matchtask(self, file, task):
         if task["__ansible_action_type__"] == 'task':

--- a/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -29,11 +29,11 @@ def _changed_in_when(item):
 
 
 class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
-    id = 'ANSIBLE0016'
+    id = '503'
     shortdesc = 'Tasks that run when changed should likely be handlers'
     description = "If a task has a `when: result.changed` setting, it's effectively " \
                   "acting as a handler"
-    tags = ['behaviour']
+    tags = ['task', 'behaviour']
 
     def matchtask(self, file, task):
         if task["__ansible_action_type__"] == 'task':

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -29,7 +29,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
     description = 'Using bare variables is deprecated. Update your ' + \
         'playbooks so that the environment value uses the full variable ' + \
         'syntax ("{{your_variable}}").'
-    tags = ['deprecated', 'formatting']
+    tags = ['deprecated', 'formatting', 'ANSIBLE0015']
 
     _jinja = re.compile("\{\{.*\}\}")
     _glob = re.compile('[][*?]')

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -24,12 +24,12 @@ from ansiblelint import AnsibleLintRule
 
 
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
-    id = 'ANSIBLE0015'
+    id = '104'
     shortdesc = 'Using bare variables is deprecated'
     description = 'Using bare variables is deprecated. Update your ' + \
         'playbooks so that the environment value uses the full variable ' + \
         'syntax ("{{your_variable}}").'
-    tags = ['formatting', 'deprecated']
+    tags = ['deprecated', 'formatting']
 
     _jinja = re.compile("\{\{.*\}\}")
     _glob = re.compile('[][*?]')

--- a/test/TestSkippedTasks.py
+++ b/test/TestSkippedTasks.py
@@ -34,6 +34,6 @@ class TestRule(unittest.TestCase):
 
     def test_runner_count(self):
         filename = 'test/skiptasks.yml'
-        tags = ['ANSIBLE0004', 'ANSIBLE0005', 'ANSIBLE0006', 'ANSIBLE0007']
+        tags = ['401', '402', '303', '302']
         runner = Runner(self.rules, filename, tags, [], [])
         self.assertEqual(len(runner.run()), 6)

--- a/test/TestWithSkipTagId.py
+++ b/test/TestWithSkipTagId.py
@@ -1,0 +1,36 @@
+import unittest
+from ansiblelint import RulesCollection, Runner
+from ansiblelint.rules.TrailingWhitespaceRule import TrailingWhitespaceRule
+
+
+class TestWithSkipTagId(unittest.TestCase):
+    collection = RulesCollection()
+    collection.register(TrailingWhitespaceRule())
+    file = 'test/with-skip-tag-id.yml'
+
+    def test_negative_no_param(self):
+        bad_runner = Runner(self.collection, self.file, [], [], [])
+        errs = bad_runner.run()
+        self.assertGreater(len(errs), 0)
+
+    def test_negative_with_id(self):
+        with_id = '201'
+        bad_runner = Runner(self.collection, self.file, [with_id], [], [])
+        errs = bad_runner.run()
+        self.assertGreater(len(errs), 0)
+
+    def test_negative_with_tag(self):
+        with_tag = 'ANSIBLE0002'
+        bad_runner = Runner(self.collection, self.file, [with_tag], [], [])
+        errs = bad_runner.run()
+        self.assertGreater(len(errs), 0)
+
+    def test_positive_skip_id(self):
+        skip_id = '201'
+        good_runner = Runner(self.collection, self.file, [], [skip_id], [])
+        self.assertEqual([], good_runner.run())
+
+    def test_positive_skip_tag(self):
+        skip_tag = 'ANSIBLE0002'
+        good_runner = Runner(self.collection, self.file, [], [skip_tag], [])
+        self.assertEqual([], good_runner.run())

--- a/test/skiptasks.yml
+++ b/test/skiptasks.yml
@@ -3,17 +3,17 @@
 
   tasks:
 
-    - name: test ANSIBLE0004
+    - name: test 401
       action: git
 
-    - name: test ANSIBLE0005
+    - name: test 402
       action: hg
 
-    - name: test ANSIBLE0006
+    - name: test 303
       command: git log
       changed_when: False
 
-    - name: test ANSIBLE0007
+    - name: test 302
       command: creates=B chmod 644 A
 
     - name: test invalid action (skip)
@@ -21,50 +21,50 @@
       tags:
         - skip_ansible_lint
 
-    - name: test ANSIBLE0004 (skip)
+    - name: test 401 (skip)
       action: git
       tags:
         - skip_ansible_lint
 
-    - name: test ANSIBLE0005 (skip)
+    - name: test 402 (skip)
       action: hg
       tags:
         - skip_ansible_lint
 
-    - name: test ANSIBLE0006 (skip)
+    - name: test 303 (skip)
       command: git log
       tags:
         - skip_ansible_lint
 
-    - name: test ANSIBLE0007 (skip)
+    - name: test 302 (skip)
       command: chmod 644 A
       tags:
         - skip_ansible_lint
 
-    - name: test ANSIBLE0004 (don't warn)
+    - name: test 401 (don't warn)
       command: git log
       args:
         warn: False
       changed_when: False
 
-    - name: test ANSIBLE0005 (don't warn)
+    - name: test 402 (don't warn)
       command: chmod 644 A
       args:
         warn: False
         creates: B
 
-    - name: test ANSIBLE0005 (warn)
+    - name: test 402 (warn)
       command: chmod 644 A
       args:
         warn: yes
         creates: B
 
-    - name: test ANSIBLE0004 (don't warn single line)
+    - name: test 401 (don't warn single line)
       command: warn=False chdir=/tmp/blah git log
       changed_when: False
 
-    - name: test ANSIBLE0005 (don't warn single line)
+    - name: test 402 (don't warn single line)
       command: warn=no creates=B chmod 644 A
 
-    - name: test ANSIBLE0005 (warn single line)
+    - name: test 402 (warn single line)
       command: warn=yes creates=B chmod 644 A

--- a/test/with-skip-tag-id.yml
+++ b/test/with-skip-tag-id.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  tasks:
+  - name: trailing whitespace on this line         
+    git:
+      repo: '{{ archive_services_repo_url }}'
+      dest: '/home/www'


### PR DESCRIPTION
In the near future the ansible galaxy dev team would like to use the default ansible-lint rules (lib/ansiblelint/rules) as part of the galaxy import process. This PR is a proposal to organize the default rules to help with display, documentation, and adding future rules. We are looking for community feedback.

Proposal:
- Have each rule be in a category, and have the id relate to the category
- Use the first tag in the rule `tags` list to denote the category
- If that seems acceptable, I took a pass at editing the tags and ids, including shortening the ids. The result matches the [pep8 error code setup](https://pep8.readthedocs.io/en/latest/intro.html#error-codes), and enables auto-generated documentation: RULE_DOCS.md